### PR TITLE
feat: codecov + comprehensive backend/frontend test coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,45 @@ jobs:
         run: uv sync --all-extras
 
       - name: Run tests with coverage
-        run: uv run pytest tests/ -v --cov=app --cov-report=term-missing
+        run: uv run pytest tests/ -v --cov=app --cov-report=term-missing --cov-report=xml
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./backend/coverage.xml
+          flags: backend
+          fail_ci_if_error: false
+
+  frontend-test:
+    name: Frontend Tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests with coverage
+        run: npm run test:coverage
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./frontend/coverage/lcov.info
+          flags: frontend
+          fail_ci_if_error: false
 
   frontend-lint:
     name: Frontend Lint

--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,9 @@ frontend/dist/
 # Database
 *.db
 *.sqlite3
+
+# Test coverage output (generated each test run, uploaded to Codecov in CI)
+coverage/
+coverage.xml
+coverage.lcov
+lcov.info

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Rae Budget
 
 [![CI](https://github.com/rae004/rae-budget/actions/workflows/ci.yml/badge.svg)](https://github.com/rae004/rae-budget/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/rae004/rae-budget/branch/main/graph/badge.svg)](https://codecov.io/gh/rae004/rae-budget)
 [![Release](https://github.com/rae004/rae-budget/actions/workflows/release-please.yml/badge.svg)](https://github.com/rae004/rae-budget/actions/workflows/release-please.yml)
 [![Version](https://img.shields.io/github/package-json/v/rae004/rae-budget?filename=frontend%2Fpackage.json&color=blue&label=version)](./CHANGELOG.md)
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](./LICENSE)

--- a/backend/app/routes/bill_templates.py
+++ b/backend/app/routes/bill_templates.py
@@ -1,3 +1,5 @@
+import json
+
 from flask import Blueprint, jsonify, request
 from pydantic import ValidationError
 
@@ -48,7 +50,7 @@ def create_bill_template():
     try:
         data = BillTemplateCreate.model_validate(request.json)
     except ValidationError as e:
-        return jsonify({"error": e.errors()}), 400
+        return jsonify({"error": json.loads(e.json())}), 400
 
     session = db.get_session()
     try:
@@ -79,7 +81,7 @@ def update_bill_template(template_id: int):
     try:
         data = BillTemplateUpdate.model_validate(request.json)
     except ValidationError as e:
-        return jsonify({"error": e.errors()}), 400
+        return jsonify({"error": json.loads(e.json())}), 400
 
     session = db.get_session()
     try:

--- a/backend/app/routes/bills.py
+++ b/backend/app/routes/bills.py
@@ -1,3 +1,5 @@
+import json
+
 from flask import Blueprint, jsonify, request
 from pydantic import ValidationError
 
@@ -36,7 +38,7 @@ def create_bill(pay_period_id: int):
     try:
         data = PayPeriodBillCreate.model_validate(request.json)
     except ValidationError as e:
-        return jsonify({"error": e.errors()}), 400
+        return jsonify({"error": json.loads(e.json())}), 400
 
     session = db.get_session()
     try:
@@ -73,7 +75,7 @@ def update_bill(bill_id: int):
     try:
         data = PayPeriodBillUpdate.model_validate(request.json)
     except ValidationError as e:
-        return jsonify({"error": e.errors()}), 400
+        return jsonify({"error": json.loads(e.json())}), 400
 
     session = db.get_session()
     try:

--- a/backend/app/routes/categories.py
+++ b/backend/app/routes/categories.py
@@ -1,3 +1,5 @@
+import json
+
 from flask import Blueprint, jsonify, request
 from pydantic import ValidationError
 
@@ -48,7 +50,7 @@ def create_category():
     try:
         data = CategoryCreate.model_validate(request.json)
     except ValidationError as e:
-        return jsonify({"error": e.errors()}), 400
+        return jsonify({"error": json.loads(e.json())}), 400
 
     session = db.get_session()
     try:
@@ -76,7 +78,7 @@ def update_category(category_id: int):
     try:
         data = CategoryUpdate.model_validate(request.json)
     except ValidationError as e:
-        return jsonify({"error": e.errors()}), 400
+        return jsonify({"error": json.loads(e.json())}), 400
 
     session = db.get_session()
     try:

--- a/backend/app/routes/data_management.py
+++ b/backend/app/routes/data_management.py
@@ -1,5 +1,6 @@
 """Data management routes for export, import, and reset operations."""
 
+import json
 from datetime import UTC, datetime
 
 from flask import Blueprint, Response, jsonify, request
@@ -139,7 +140,7 @@ def import_data():
     try:
         data = DataImport.model_validate(request.json)
     except ValidationError as e:
-        return jsonify({"error": e.errors()}), 400
+        return jsonify({"error": json.loads(e.json())}), 400
 
     session = db.get_session()
     try:

--- a/backend/app/routes/pay_periods.py
+++ b/backend/app/routes/pay_periods.py
@@ -1,3 +1,5 @@
+import json
+
 from flask import Blueprint, jsonify, request
 from pydantic import ValidationError
 
@@ -96,7 +98,7 @@ def create_pay_period():
     try:
         data = PayPeriodCreate.model_validate(request.json)
     except ValidationError as e:
-        return jsonify({"error": e.errors()}), 400
+        return jsonify({"error": json.loads(e.json())}), 400
 
     session = db.get_session()
     try:
@@ -133,7 +135,7 @@ def update_pay_period(pay_period_id: int):
     try:
         data = PayPeriodUpdate.model_validate(request.json)
     except ValidationError as e:
-        return jsonify({"error": e.errors()}), 400
+        return jsonify({"error": json.loads(e.json())}), 400
 
     session = db.get_session()
     try:

--- a/backend/app/routes/spending.py
+++ b/backend/app/routes/spending.py
@@ -1,3 +1,5 @@
+import json
+
 from flask import Blueprint, jsonify, request
 from pydantic import ValidationError
 
@@ -36,7 +38,7 @@ def create_spending(pay_period_id: int):
     try:
         data = SpendingEntryCreate.model_validate(request.json)
     except ValidationError as e:
-        return jsonify({"error": e.errors()}), 400
+        return jsonify({"error": json.loads(e.json())}), 400
 
     session = db.get_session()
     try:
@@ -71,7 +73,7 @@ def update_spending(spending_id: int):
     try:
         data = SpendingEntryUpdate.model_validate(request.json)
     except ValidationError as e:
-        return jsonify({"error": e.errors()}), 400
+        return jsonify({"error": json.loads(e.json())}), 400
 
     session = db.get_session()
     try:

--- a/backend/tests/test_bill_templates.py
+++ b/backend/tests/test_bill_templates.py
@@ -1,0 +1,157 @@
+"""Tests for bill template routes."""
+
+import json
+from decimal import Decimal
+
+from app.models import BillTemplate
+
+
+class TestListBillTemplates:
+    """GET /api/bill-templates"""
+
+    def test_empty(self, client, session):
+        response = client.get("/api/bill-templates")
+        assert response.status_code == 200
+        assert response.get_json() == []
+
+    def test_returns_sorted_by_name(self, client, session):
+        session.add_all(
+            [
+                BillTemplate(name="Zoo", default_amount=Decimal("10.00")),
+                BillTemplate(name="Apple", default_amount=Decimal("20.00")),
+                BillTemplate(name="Mango", default_amount=Decimal("30.00")),
+            ]
+        )
+        session.commit()
+
+        response = client.get("/api/bill-templates")
+        names = [t["name"] for t in response.get_json()]
+        assert names == ["Apple", "Mango", "Zoo"]
+
+
+class TestGetBillTemplate:
+    """GET /api/bill-templates/:id"""
+
+    def test_found(self, client, sample_bill_template):
+        response = client.get(f"/api/bill-templates/{sample_bill_template.id}")
+        assert response.status_code == 200
+        body = response.get_json()
+        assert body["name"] == "Rent"
+        assert body["default_amount"] == "1500.00"
+
+    def test_not_found(self, client, session):
+        response = client.get("/api/bill-templates/9999")
+        assert response.status_code == 404
+
+
+class TestCreateBillTemplate:
+    """POST /api/bill-templates"""
+
+    def test_create_minimal(self, client, session):
+        response = client.post(
+            "/api/bill-templates",
+            data=json.dumps({"name": "Internet", "default_amount": 75}),
+            content_type="application/json",
+        )
+        assert response.status_code == 201
+        body = response.get_json()
+        assert body["name"] == "Internet"
+        assert body["is_recurring"] is True
+
+    def test_create_full(self, client, sample_category):
+        cat_id = sample_category.id
+        response = client.post(
+            "/api/bill-templates",
+            data=json.dumps(
+                {
+                    "name": "Streaming",
+                    "default_amount": 15.99,
+                    "due_day_of_month": 15,
+                    "is_recurring": True,
+                    "category_id": cat_id,
+                    "notes": "Annual plan",
+                }
+            ),
+            content_type="application/json",
+        )
+        assert response.status_code == 201
+        body = response.get_json()
+        assert body["due_day_of_month"] == 15
+        assert body["category_id"] == cat_id
+        assert body["notes"] == "Annual plan"
+
+    def test_create_validation_error(self, client, session):
+        """Missing required fields returns 400."""
+        response = client.post(
+            "/api/bill-templates",
+            data=json.dumps({}),
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+
+    def test_create_rejects_invalid_due_day(self, client, session):
+        response = client.post(
+            "/api/bill-templates",
+            data=json.dumps(
+                {
+                    "name": "Bad",
+                    "default_amount": 1,
+                    "due_day_of_month": 32,
+                }
+            ),
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+
+
+class TestUpdateBillTemplate:
+    """PUT /api/bill-templates/:id"""
+
+    def test_update_name(self, client, sample_bill_template):
+        response = client.put(
+            f"/api/bill-templates/{sample_bill_template.id}",
+            data=json.dumps({"name": "Mortgage"}),
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+        assert response.get_json()["name"] == "Mortgage"
+
+    def test_partial_update_preserves_other_fields(self, client, sample_bill_template):
+        original_amount = sample_bill_template.default_amount
+        response = client.put(
+            f"/api/bill-templates/{sample_bill_template.id}",
+            data=json.dumps({"name": "Renamed"}),
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+        assert response.get_json()["default_amount"] == f"{original_amount:.2f}"
+
+    def test_validation_error(self, client, sample_bill_template):
+        response = client.put(
+            f"/api/bill-templates/{sample_bill_template.id}",
+            data=json.dumps({"default_amount": -1}),
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+
+    def test_not_found(self, client, session):
+        response = client.put(
+            "/api/bill-templates/9999",
+            data=json.dumps({"name": "x"}),
+            content_type="application/json",
+        )
+        assert response.status_code == 404
+
+
+class TestDeleteBillTemplate:
+    """DELETE /api/bill-templates/:id"""
+
+    def test_delete(self, client, session, sample_bill_template):
+        template_id = sample_bill_template.id
+        response = client.delete(f"/api/bill-templates/{template_id}")
+        assert response.status_code == 204
+        assert session.query(BillTemplate).filter_by(id=template_id).first() is None
+
+    def test_not_found(self, client, session):
+        response = client.delete("/api/bill-templates/9999")
+        assert response.status_code == 404

--- a/backend/tests/test_bills.py
+++ b/backend/tests/test_bills.py
@@ -1,3 +1,4 @@
+import json
 from datetime import date
 from decimal import Decimal
 
@@ -91,3 +92,135 @@ class TestPayPeriodBillModel:
         """Pay period bill has readable repr."""
         assert "Rent" in repr(sample_bill)
         assert "1500" in repr(sample_bill)
+
+
+class TestListBills:
+    """GET /api/pay-periods/:id/bills"""
+
+    def test_empty_for_new_pay_period(self, client, sample_pay_period):
+        pp_id = sample_pay_period.id
+        response = client.get(f"/api/pay-periods/{pp_id}/bills")
+        assert response.status_code == 200
+        assert response.get_json() == []
+
+    def test_returns_bills(self, client, sample_pay_period, sample_bill):
+        pp_id = sample_pay_period.id
+        response = client.get(f"/api/pay-periods/{pp_id}/bills")
+        body = response.get_json()
+        assert len(body) == 1
+        assert body[0]["name"] == "Rent"
+
+    def test_pay_period_not_found(self, client, session):
+        response = client.get("/api/pay-periods/9999/bills")
+        assert response.status_code == 404
+
+
+class TestCreateBill:
+    """POST /api/pay-periods/:id/bills"""
+
+    def test_create_minimal(self, client, sample_pay_period):
+        pp_id = sample_pay_period.id
+        response = client.post(
+            f"/api/pay-periods/{pp_id}/bills",
+            data=json.dumps({"name": "Internet", "amount": 75}),
+            content_type="application/json",
+        )
+        assert response.status_code == 201
+        body = response.get_json()
+        assert body["name"] == "Internet"
+        assert body["pay_period_id"] == pp_id
+        assert body["is_paid"] is False
+
+    def test_create_with_template_link(
+        self, client, sample_pay_period, sample_bill_template
+    ):
+        pp_id = sample_pay_period.id
+        template_id = sample_bill_template.id
+        response = client.post(
+            f"/api/pay-periods/{pp_id}/bills",
+            data=json.dumps(
+                {
+                    "name": "Rent",
+                    "amount": 1500,
+                    "bill_template_id": template_id,
+                    "due_date": "2026-04-01",
+                }
+            ),
+            content_type="application/json",
+        )
+        assert response.status_code == 201
+        assert response.get_json()["bill_template_id"] == template_id
+
+    def test_create_validation_error(self, client, sample_pay_period):
+        pp_id = sample_pay_period.id
+        response = client.post(
+            f"/api/pay-periods/{pp_id}/bills",
+            data=json.dumps({"amount": 100}),  # missing name
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+
+    def test_create_pay_period_not_found(self, client, session):
+        response = client.post(
+            "/api/pay-periods/9999/bills",
+            data=json.dumps({"name": "x", "amount": 1}),
+            content_type="application/json",
+        )
+        assert response.status_code == 404
+
+
+class TestUpdateBill:
+    """PUT /api/bills/:id"""
+
+    def test_update_amount(self, client, sample_bill):
+        bill_id = sample_bill.id
+        response = client.put(
+            f"/api/bills/{bill_id}",
+            data=json.dumps({"amount": 1600}),
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+        assert response.get_json()["amount"] == "1600.00"
+
+    def test_mark_paid(self, client, sample_bill):
+        bill_id = sample_bill.id
+        response = client.put(
+            f"/api/bills/{bill_id}",
+            data=json.dumps({"is_paid": True, "paid_date": "2026-04-02"}),
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+        body = response.get_json()
+        assert body["is_paid"] is True
+        assert body["paid_date"] == "2026-04-02"
+
+    def test_validation_error(self, client, sample_bill):
+        bill_id = sample_bill.id
+        response = client.put(
+            f"/api/bills/{bill_id}",
+            data=json.dumps({"amount": -1}),
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+
+    def test_not_found(self, client, session):
+        response = client.put(
+            "/api/bills/9999",
+            data=json.dumps({"name": "x"}),
+            content_type="application/json",
+        )
+        assert response.status_code == 404
+
+
+class TestDeleteBill:
+    """DELETE /api/bills/:id"""
+
+    def test_delete(self, client, session, sample_bill):
+        bill_id = sample_bill.id
+        response = client.delete(f"/api/bills/{bill_id}")
+        assert response.status_code == 204
+        assert session.query(PayPeriodBill).filter_by(id=bill_id).first() is None
+
+    def test_not_found(self, client, session):
+        response = client.delete("/api/bills/9999")
+        assert response.status_code == 404

--- a/backend/tests/test_categories.py
+++ b/backend/tests/test_categories.py
@@ -1,0 +1,249 @@
+"""Tests for category routes."""
+
+import json
+from datetime import date
+from decimal import Decimal
+
+from app.models import BillTemplate, Category, SpendingEntry
+
+
+class TestListCategories:
+    """GET /api/categories"""
+
+    def test_empty(self, client, session):
+        """Returns [] when no categories exist."""
+        response = client.get("/api/categories")
+        assert response.status_code == 200
+        assert response.get_json() == []
+
+    def test_returns_categories_sorted_by_name(self, client, session):
+        """Categories come back sorted alphabetically."""
+        session.add_all(
+            [
+                Category(name="Zoo", color="#000000"),
+                Category(name="Apple", color="#ff0000"),
+                Category(name="Mango", color="#00ff00"),
+            ]
+        )
+        session.commit()
+
+        response = client.get("/api/categories")
+        names = [c["name"] for c in response.get_json()]
+        assert names == ["Apple", "Mango", "Zoo"]
+
+
+class TestGetCategory:
+    """GET /api/categories/:id"""
+
+    def test_found(self, client, sample_category):
+        response = client.get(f"/api/categories/{sample_category.id}")
+        assert response.status_code == 200
+        assert response.get_json()["name"] == "Food"
+
+    def test_not_found(self, client, session):
+        response = client.get("/api/categories/9999")
+        assert response.status_code == 404
+        assert response.get_json() == {"error": "Category not found"}
+
+
+class TestCreateCategory:
+    """POST /api/categories"""
+
+    def test_create_minimal(self, client, session):
+        """Can create with just a name."""
+        response = client.post(
+            "/api/categories",
+            data=json.dumps({"name": "Groceries"}),
+            content_type="application/json",
+        )
+        assert response.status_code == 201
+        body = response.get_json()
+        assert body["name"] == "Groceries"
+        assert body["id"] is not None
+
+    def test_create_full(self, client, session):
+        """Can create with name, description, color."""
+        response = client.post(
+            "/api/categories",
+            data=json.dumps(
+                {
+                    "name": "Travel",
+                    "description": "Flights and hotels",
+                    "color": "#3b82f6",
+                }
+            ),
+            content_type="application/json",
+        )
+        assert response.status_code == 201
+        body = response.get_json()
+        assert body["description"] == "Flights and hotels"
+        assert body["color"] == "#3b82f6"
+
+    def test_create_validation_error(self, client, session):
+        """Missing required name returns 400."""
+        response = client.post(
+            "/api/categories",
+            data=json.dumps({}),
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+        assert "error" in response.get_json()
+
+
+class TestUpdateCategory:
+    """PUT /api/categories/:id"""
+
+    def test_update_name(self, client, sample_category):
+        response = client.put(
+            f"/api/categories/{sample_category.id}",
+            data=json.dumps({"name": "Dining Out"}),
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+        assert response.get_json()["name"] == "Dining Out"
+
+    def test_partial_update_preserves_other_fields(self, client, sample_category):
+        """Updating only one field leaves the others intact."""
+        original_color = sample_category.color
+        response = client.put(
+            f"/api/categories/{sample_category.id}",
+            data=json.dumps({"name": "Renamed"}),
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+        body = response.get_json()
+        assert body["name"] == "Renamed"
+        assert body["color"] == original_color
+
+    def test_not_found(self, client, session):
+        response = client.put(
+            "/api/categories/9999",
+            data=json.dumps({"name": "x"}),
+            content_type="application/json",
+        )
+        assert response.status_code == 404
+
+
+class TestDeleteCategory:
+    """DELETE /api/categories/:id — covers the in-use guard + force override."""
+
+    def test_delete_unused_category(self, client, session, sample_category):
+        """An unreferenced category can be deleted with no force flag."""
+        response = client.delete(f"/api/categories/{sample_category.id}")
+        assert response.status_code == 204
+        assert session.query(Category).filter_by(id=sample_category.id).first() is None
+
+    def test_delete_not_found(self, client, session):
+        response = client.delete("/api/categories/9999")
+        assert response.status_code == 404
+
+    def test_delete_in_use_by_spending_returns_409(
+        self, client, session, sample_category, sample_pay_period
+    ):
+        """Category referenced by spending entries returns 409 with counts."""
+        session.add(
+            SpendingEntry(
+                pay_period_id=sample_pay_period.id,
+                category_id=sample_category.id,
+                description="Lunch",
+                amount=Decimal("12.00"),
+                spent_date=date(2026, 4, 10),
+            )
+        )
+        session.commit()
+
+        response = client.delete(f"/api/categories/{sample_category.id}")
+        assert response.status_code == 409
+        body = response.get_json()
+        assert body["error"] == "in_use"
+        assert body["spending_entries"] == 1
+        assert body["bill_templates"] == 0
+
+    def test_delete_in_use_by_bill_template_returns_409(
+        self, client, session, sample_category
+    ):
+        """Category referenced by bill templates returns 409 with counts."""
+        session.add(
+            BillTemplate(
+                name="Streaming",
+                default_amount=Decimal("15.00"),
+                category_id=sample_category.id,
+            )
+        )
+        session.commit()
+
+        response = client.delete(f"/api/categories/{sample_category.id}")
+        assert response.status_code == 409
+        body = response.get_json()
+        assert body["bill_templates"] == 1
+        assert body["spending_entries"] == 0
+
+    def test_delete_in_use_by_both_returns_combined_counts(
+        self, client, session, sample_category, sample_pay_period
+    ):
+        """409 body shows both counts when category is referenced by both."""
+        session.add(
+            BillTemplate(
+                name="Streaming",
+                default_amount=Decimal("15.00"),
+                category_id=sample_category.id,
+            )
+        )
+        session.add(
+            SpendingEntry(
+                pay_period_id=sample_pay_period.id,
+                category_id=sample_category.id,
+                description="Lunch",
+                amount=Decimal("12.00"),
+                spent_date=date(2026, 4, 10),
+            )
+        )
+        session.commit()
+
+        response = client.delete(f"/api/categories/{sample_category.id}")
+        assert response.status_code == 409
+        body = response.get_json()
+        assert body["bill_templates"] == 1
+        assert body["spending_entries"] == 1
+
+    def test_delete_with_force_bypasses_in_use_check(
+        self, client, session, sample_category, sample_pay_period
+    ):
+        """?force=true deletes even when references exist."""
+        session.add(
+            SpendingEntry(
+                pay_period_id=sample_pay_period.id,
+                category_id=sample_category.id,
+                description="Lunch",
+                amount=Decimal("12.00"),
+                spent_date=date(2026, 4, 10),
+            )
+        )
+        session.commit()
+
+        response = client.delete(f"/api/categories/{sample_category.id}?force=true")
+        assert response.status_code == 204
+        assert session.query(Category).filter_by(id=sample_category.id).first() is None
+
+    def test_force_query_param_is_case_insensitive(self, client, sample_category):
+        """force=TRUE works as well as force=true."""
+        response = client.delete(f"/api/categories/{sample_category.id}?force=TRUE")
+        assert response.status_code == 204
+
+    def test_force_false_still_runs_in_use_check(
+        self, client, session, sample_category, sample_pay_period
+    ):
+        """?force=false (or any other value) runs the guard."""
+        session.add(
+            SpendingEntry(
+                pay_period_id=sample_pay_period.id,
+                category_id=sample_category.id,
+                description="Lunch",
+                amount=Decimal("12.00"),
+                spent_date=date(2026, 4, 10),
+            )
+        )
+        session.commit()
+
+        response = client.delete(f"/api/categories/{sample_category.id}?force=false")
+        assert response.status_code == 409

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,0 +1,26 @@
+"""Tests for the health check endpoint."""
+
+from unittest.mock import patch
+
+from app.extensions import db
+
+
+class TestHealthCheck:
+    """GET /api/health"""
+
+    def test_returns_healthy_when_db_is_reachable(self, client, session):
+        """When the DB session executes a SELECT, status is healthy + connected."""
+        response = client.get("/api/health")
+        assert response.status_code == 200
+        body = response.get_json()
+        assert body["status"] == "healthy"
+        assert body["database"] == "connected"
+
+    def test_returns_degraded_when_db_session_raises(self, client, session):
+        """When db.get_session() blows up, status flips to degraded/disconnected."""
+        with patch.object(db, "get_session", side_effect=RuntimeError("boom")):
+            response = client.get("/api/health")
+        assert response.status_code == 200  # health endpoint always 200
+        body = response.get_json()
+        assert body["status"] == "degraded"
+        assert body["database"] == "disconnected"

--- a/backend/tests/test_pay_periods.py
+++ b/backend/tests/test_pay_periods.py
@@ -1,7 +1,8 @@
+import json
 from datetime import date
 from decimal import Decimal
 
-from app.models import PayPeriod
+from app.models import BillTemplate, PayPeriod
 
 
 class TestPayPeriodModel:
@@ -54,3 +55,305 @@ class TestPayPeriodModel:
         """Pay period has readable repr."""
         assert "2026-04-06" in repr(sample_pay_period)
         assert "2026-04-19" in repr(sample_pay_period)
+
+
+class TestListPayPeriods:
+    """GET /api/pay-periods"""
+
+    def test_empty(self, client, session):
+        response = client.get("/api/pay-periods")
+        assert response.status_code == 200
+        assert response.get_json() == []
+
+    def test_returns_descending_by_start_date(self, client, session):
+        """Most recent pay period comes first."""
+        session.add_all(
+            [
+                PayPeriod(
+                    start_date=date(2026, 1, 6),
+                    end_date=date(2026, 1, 19),
+                    expected_income=Decimal("2500.00"),
+                ),
+                PayPeriod(
+                    start_date=date(2026, 4, 6),
+                    end_date=date(2026, 4, 19),
+                    expected_income=Decimal("2500.00"),
+                ),
+                PayPeriod(
+                    start_date=date(2026, 2, 20),
+                    end_date=date(2026, 3, 5),
+                    expected_income=Decimal("2500.00"),
+                ),
+            ]
+        )
+        session.commit()
+
+        response = client.get("/api/pay-periods")
+        starts = [p["start_date"] for p in response.get_json()]
+        assert starts == ["2026-04-06", "2026-02-20", "2026-01-06"]
+
+
+class TestSuggestPayPeriod:
+    """GET /api/pay-periods/suggest"""
+
+    def test_default_uses_today(self, client, session):
+        """Returns ISO-formatted start_date and end_date."""
+        response = client.get("/api/pay-periods/suggest")
+        assert response.status_code == 200
+        body = response.get_json()
+        assert "start_date" in body
+        assert "end_date" in body
+
+    def test_with_explicit_from_date(self, client, session):
+        """Reference date param drives the suggestion."""
+        response = client.get("/api/pay-periods/suggest?from_date=2026-04-01")
+        assert response.status_code == 200
+        body = response.get_json()
+        # Per the 6th/20th schedule, after 2026-04-01 the next pay date is 2026-04-06
+        assert body["start_date"] == "2026-04-06"
+        assert body["end_date"] == "2026-04-19"
+
+    def test_invalid_date_returns_400(self, client, session):
+        response = client.get("/api/pay-periods/suggest?from_date=not-a-date")
+        assert response.status_code == 400
+        assert "YYYY-MM-DD" in response.get_json()["error"]
+
+
+class TestGetPayPeriod:
+    """GET /api/pay-periods/:id (with calculated summary)"""
+
+    def test_returns_pay_period_with_summary(self, client, sample_pay_period):
+        response = client.get(f"/api/pay-periods/{sample_pay_period.id}")
+        assert response.status_code == 200
+        body = response.get_json()
+        assert body["id"] == sample_pay_period.id
+        assert "summary" in body
+        for key in ("bill_total", "spending_total", "running_total", "remaining"):
+            assert key in body["summary"]
+
+    def test_summary_reflects_bills_and_spending(
+        self, client, session, sample_pay_period, sample_bill, sample_spending
+    ):
+        response = client.get(f"/api/pay-periods/{sample_pay_period.id}")
+        body = response.get_json()
+        # sample_bill is 1500, sample_spending is 150 → running 1650, remaining = 2500 - 1650 = 850
+        assert body["summary"]["bill_total"] == "1500.00"
+        assert body["summary"]["spending_total"] == "150.00"
+        assert body["summary"]["running_total"] == "1650.00"
+        assert body["summary"]["remaining"] == "850.00"
+
+    def test_not_found(self, client, session):
+        response = client.get("/api/pay-periods/9999")
+        assert response.status_code == 404
+
+
+class TestCreatePayPeriod:
+    """POST /api/pay-periods"""
+
+    def test_create_minimal(self, client, session):
+        response = client.post(
+            "/api/pay-periods",
+            data=json.dumps(
+                {
+                    "start_date": "2026-04-06",
+                    "end_date": "2026-04-19",
+                    "expected_income": 2500,
+                }
+            ),
+            content_type="application/json",
+        )
+        assert response.status_code == 201
+        body = response.get_json()
+        assert body["start_date"] == "2026-04-06"
+        assert body["expected_income"] == "2500.00"
+
+    def test_validation_error_when_end_before_start(self, client, session):
+        """The schema's model_validator rejects end < start with a clean 400."""
+        response = client.post(
+            "/api/pay-periods",
+            data=json.dumps(
+                {
+                    "start_date": "2026-04-19",
+                    "end_date": "2026-04-06",
+                    "expected_income": 2500,
+                }
+            ),
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+        body = response.get_json()
+        assert "error" in body
+        # The serialized error mentions the validator's message
+        assert any("end_date" in err.get("msg", "") for err in body["error"])
+
+    def test_validation_error_when_negative_income(self, client, session):
+        response = client.post(
+            "/api/pay-periods",
+            data=json.dumps(
+                {
+                    "start_date": "2026-04-06",
+                    "end_date": "2026-04-19",
+                    "expected_income": -100,
+                }
+            ),
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+
+    def test_populate_bills_param_creates_bills_from_templates(
+        self, client, session, sample_bill_template
+    ):
+        """?populate_bills=true seeds bills from active templates."""
+        response = client.post(
+            "/api/pay-periods?populate_bills=true",
+            data=json.dumps(
+                {
+                    "start_date": "2026-04-06",
+                    "end_date": "2026-04-19",
+                    "expected_income": 2500,
+                }
+            ),
+            content_type="application/json",
+        )
+        assert response.status_code == 201
+        # The detail endpoint should now show the bill in the total
+        pay_period_id = response.get_json()["id"]
+        detail = client.get(f"/api/pay-periods/{pay_period_id}")
+        assert detail.get_json()["summary"]["bill_total"] != "0.00"
+
+
+class TestUpdatePayPeriod:
+    """PUT /api/pay-periods/:id"""
+
+    def test_update_notes(self, client, sample_pay_period):
+        response = client.put(
+            f"/api/pay-periods/{sample_pay_period.id}",
+            data=json.dumps({"notes": "Updated notes"}),
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+        assert response.get_json()["notes"] == "Updated notes"
+
+    def test_update_additional_income(self, client, sample_pay_period):
+        response = client.put(
+            f"/api/pay-periods/{sample_pay_period.id}",
+            data=json.dumps(
+                {
+                    "additional_income": 100,
+                    "additional_income_description": "Side gig",
+                }
+            ),
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+        body = response.get_json()
+        assert body["additional_income"] == "100.00"
+        assert body["additional_income_description"] == "Side gig"
+
+    def test_partial_update_preserves_other_fields(self, client, sample_pay_period):
+        original_income = sample_pay_period.expected_income
+        response = client.put(
+            f"/api/pay-periods/{sample_pay_period.id}",
+            data=json.dumps({"notes": "Just notes"}),
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+        assert response.get_json()["expected_income"] == f"{original_income:.2f}"
+
+    def test_validation_error(self, client, sample_pay_period):
+        response = client.put(
+            f"/api/pay-periods/{sample_pay_period.id}",
+            data=json.dumps({"expected_income": -1}),
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+
+    def test_not_found(self, client, session):
+        response = client.put(
+            "/api/pay-periods/9999",
+            data=json.dumps({"notes": "x"}),
+            content_type="application/json",
+        )
+        assert response.status_code == 404
+
+
+class TestDeletePayPeriod:
+    """DELETE /api/pay-periods/:id"""
+
+    def test_delete(self, client, session, sample_pay_period):
+        response = client.delete(f"/api/pay-periods/{sample_pay_period.id}")
+        assert response.status_code == 204
+        assert (
+            session.query(PayPeriod).filter_by(id=sample_pay_period.id).first() is None
+        )
+
+    def test_not_found(self, client, session):
+        response = client.delete("/api/pay-periods/9999")
+        assert response.status_code == 404
+
+
+class TestRepopulateBills:
+    """POST /api/pay-periods/:id/repopulate-bills"""
+
+    def test_repopulates_for_one_pay_period(
+        self, client, session, sample_pay_period, sample_bill_template
+    ):
+        # Capture id before the request — the route closes the test's session in
+        # a finally block, which detaches the fixture object.
+        pp_id = sample_pay_period.id
+        response = client.post(f"/api/pay-periods/{pp_id}/repopulate-bills")
+        assert response.status_code == 200
+        body = response.get_json()
+        assert body["pay_period_id"] == pp_id
+        assert "bills_deleted" in body
+        assert "bills_created" in body
+
+    def test_pay_period_not_found(self, client, session):
+        response = client.post("/api/pay-periods/9999/repopulate-bills")
+        assert response.status_code == 404
+
+
+class TestRepopulateAllBills:
+    """POST /api/pay-periods/repopulate-all-bills"""
+
+    def test_requires_confirmation_header(self, client, session):
+        response = client.post("/api/pay-periods/repopulate-all-bills")
+        assert response.status_code == 400
+        assert "X-Confirm-Repopulate" in response.get_json()["error"]
+
+    def test_rejects_wrong_header_value(self, client, session):
+        response = client.post(
+            "/api/pay-periods/repopulate-all-bills",
+            headers={"X-Confirm-Repopulate": "WRONG"},
+        )
+        assert response.status_code == 400
+
+    def test_runs_with_correct_header(
+        self, client, session, sample_pay_period, sample_bill_template
+    ):
+        # Add a second pay period so the loop runs more than once
+        session.add(
+            BillTemplate(
+                name="Internet",
+                default_amount=Decimal("75.00"),
+                due_day_of_month=10,
+            )
+        )
+        session.add(
+            PayPeriod(
+                start_date=date(2026, 5, 6),
+                end_date=date(2026, 5, 19),
+                expected_income=Decimal("2500.00"),
+            )
+        )
+        session.commit()
+
+        response = client.post(
+            "/api/pay-periods/repopulate-all-bills",
+            headers={"X-Confirm-Repopulate": "REPOPULATE-ALL"},
+        )
+        assert response.status_code == 200
+        body = response.get_json()
+        assert body["pay_periods_updated"] == 2
+        assert "total_bills_deleted" in body
+        assert "total_bills_created" in body

--- a/backend/tests/test_spending.py
+++ b/backend/tests/test_spending.py
@@ -1,3 +1,4 @@
+import json
 from datetime import date
 from decimal import Decimal
 
@@ -64,3 +65,145 @@ class TestSpendingEntryModel:
         """Spending entry has readable repr."""
         assert "Groceries" in repr(sample_spending)
         assert "150" in repr(sample_spending)
+
+
+class TestListSpending:
+    """GET /api/pay-periods/:id/spending"""
+
+    def test_empty_for_new_pay_period(self, client, sample_pay_period):
+        pp_id = sample_pay_period.id
+        response = client.get(f"/api/pay-periods/{pp_id}/spending")
+        assert response.status_code == 200
+        assert response.get_json() == []
+
+    def test_returns_entries(self, client, sample_pay_period, sample_spending):
+        pp_id = sample_pay_period.id
+        response = client.get(f"/api/pay-periods/{pp_id}/spending")
+        body = response.get_json()
+        assert len(body) == 1
+        assert body[0]["description"] == "Groceries at Publix"
+
+    def test_pay_period_not_found(self, client, session):
+        response = client.get("/api/pay-periods/9999/spending")
+        assert response.status_code == 404
+
+
+class TestCreateSpending:
+    """POST /api/pay-periods/:id/spending"""
+
+    def test_create_minimal(self, client, sample_pay_period):
+        pp_id = sample_pay_period.id
+        response = client.post(
+            f"/api/pay-periods/{pp_id}/spending",
+            data=json.dumps(
+                {
+                    "description": "Coffee",
+                    "amount": 4.50,
+                    "spent_date": "2026-04-08",
+                }
+            ),
+            content_type="application/json",
+        )
+        assert response.status_code == 201
+        body = response.get_json()
+        assert body["description"] == "Coffee"
+        assert body["pay_period_id"] == pp_id
+
+    def test_create_with_category(self, client, sample_pay_period, sample_category):
+        pp_id = sample_pay_period.id
+        cat_id = sample_category.id
+        response = client.post(
+            f"/api/pay-periods/{pp_id}/spending",
+            data=json.dumps(
+                {
+                    "description": "Lunch",
+                    "amount": 12,
+                    "spent_date": "2026-04-10",
+                    "category_id": cat_id,
+                }
+            ),
+            content_type="application/json",
+        )
+        assert response.status_code == 201
+        assert response.get_json()["category_id"] == cat_id
+
+    def test_create_validation_error(self, client, sample_pay_period):
+        pp_id = sample_pay_period.id
+        response = client.post(
+            f"/api/pay-periods/{pp_id}/spending",
+            data=json.dumps({"amount": 5}),  # missing description, spent_date
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+
+    def test_create_pay_period_not_found(self, client, session):
+        response = client.post(
+            "/api/pay-periods/9999/spending",
+            data=json.dumps(
+                {
+                    "description": "x",
+                    "amount": 1,
+                    "spent_date": "2026-04-10",
+                }
+            ),
+            content_type="application/json",
+        )
+        assert response.status_code == 404
+
+
+class TestUpdateSpending:
+    """PUT /api/spending/:id"""
+
+    def test_update_amount(self, client, sample_spending):
+        entry_id = sample_spending.id
+        response = client.put(
+            f"/api/spending/{entry_id}",
+            data=json.dumps({"amount": 175}),
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+        assert response.get_json()["amount"] == "175.00"
+
+    def test_partial_update(self, client, sample_spending):
+        entry_id = sample_spending.id
+        original_desc = sample_spending.description
+        response = client.put(
+            f"/api/spending/{entry_id}",
+            data=json.dumps({"notes": "added a note"}),
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+        body = response.get_json()
+        assert body["notes"] == "added a note"
+        assert body["description"] == original_desc
+
+    def test_validation_error(self, client, sample_spending):
+        entry_id = sample_spending.id
+        response = client.put(
+            f"/api/spending/{entry_id}",
+            data=json.dumps({"amount": -1}),
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+
+    def test_not_found(self, client, session):
+        response = client.put(
+            "/api/spending/9999",
+            data=json.dumps({"description": "x"}),
+            content_type="application/json",
+        )
+        assert response.status_code == 404
+
+
+class TestDeleteSpending:
+    """DELETE /api/spending/:id"""
+
+    def test_delete(self, client, session, sample_spending):
+        entry_id = sample_spending.id
+        response = client.delete(f"/api/spending/{entry_id}")
+        assert response.status_code == 204
+        assert session.query(SpendingEntry).filter_by(id=entry_id).first() is None
+
+    def test_not_found(self, client, session):
+        response = client.delete("/api/spending/9999")
+        assert response.status_code == 404

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "rae-budget-frontend",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
         "@tanstack/react-form": "^1.0.0",
         "@tanstack/react-query": "^5.60.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24,6 +24,7 @@
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^4.3.4",
+        "@vitest/coverage-v8": "^3.2.4",
         "autoprefixer": "^10.4.20",
         "daisyui": "^5.0.0",
         "eslint": "^9.15.0",
@@ -43,15 +44,13 @@
       "version": "4.4.4",
       "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
       "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -59,12 +58,24 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@asamuzakjp/css-color": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
       "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@csstools/css-calc": "^2.1.3",
         "@csstools/css-color-parser": "^3.0.9",
@@ -77,15 +88,13 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
-      "license": "ISC"
+      "dev": true
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
       "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
@@ -100,7 +109,6 @@
       "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
       "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -110,7 +118,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -141,7 +148,6 @@
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
       "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.0",
         "@babel/types": "^7.29.0",
@@ -158,7 +164,6 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
       "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.28.6",
         "@babel/helper-validator-option": "^7.27.1",
@@ -175,7 +180,6 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
       "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -185,7 +189,6 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
       "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.28.6",
         "@babel/types": "^7.28.6"
@@ -199,7 +202,6 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
       "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.28.6",
         "@babel/helper-validator-identifier": "^7.28.5",
@@ -217,7 +219,6 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
       "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -227,7 +228,6 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -237,7 +237,6 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -247,7 +246,6 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
       "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -257,7 +255,6 @@
       "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
       "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.28.6",
         "@babel/types": "^7.29.0"
@@ -271,7 +268,6 @@
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
       "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.0"
       },
@@ -287,7 +283,6 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
       "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
       },
@@ -303,7 +298,6 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
       "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.27.1"
       },
@@ -319,7 +313,6 @@
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
       "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -329,7 +322,6 @@
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
       "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/parser": "^7.28.6",
@@ -344,7 +336,6 @@
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
       "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -363,13 +354,21 @@
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
       "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
         "@babel/helper-validator-identifier": "^7.28.5"
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@csstools/color-helpers": {
@@ -387,7 +386,6 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
-      "license": "MIT-0",
       "engines": {
         "node": ">=18"
       }
@@ -407,7 +405,6 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
-      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -431,7 +428,6 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "@csstools/color-helpers": "^5.1.0",
         "@csstools/css-calc": "^2.1.4"
@@ -459,7 +455,6 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
-      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -482,7 +477,6 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
-      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
@@ -495,7 +489,6 @@
         "ppc64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "aix"
@@ -512,7 +505,6 @@
         "arm"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -529,7 +521,6 @@
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -546,7 +537,6 @@
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -563,7 +553,6 @@
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -580,7 +569,6 @@
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -597,7 +585,6 @@
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -614,7 +601,6 @@
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -631,7 +617,6 @@
         "arm"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -648,7 +633,6 @@
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -665,7 +649,6 @@
         "ia32"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -682,7 +665,6 @@
         "loong64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -699,7 +681,6 @@
         "mips64el"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -716,7 +697,6 @@
         "ppc64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -733,7 +713,6 @@
         "riscv64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -750,7 +729,6 @@
         "s390x"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -767,7 +745,6 @@
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -784,7 +761,6 @@
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "netbsd"
@@ -801,7 +777,6 @@
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "netbsd"
@@ -818,7 +793,6 @@
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
@@ -835,7 +809,6 @@
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
@@ -852,7 +825,6 @@
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "openharmony"
@@ -869,7 +841,6 @@
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "sunos"
@@ -886,7 +857,6 @@
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -903,7 +873,6 @@
         "ia32"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -920,7 +889,6 @@
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -934,7 +902,6 @@
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
       "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "eslint-visitor-keys": "^3.4.3"
       },
@@ -953,7 +920,6 @@
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
       "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -966,7 +932,6 @@
       "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
       "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
       }
@@ -976,7 +941,6 @@
       "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
       "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "@eslint/object-schema": "^2.1.7",
         "debug": "^4.3.1",
@@ -991,7 +955,6 @@
       "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
       "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "@eslint/core": "^0.17.0"
       },
@@ -1004,7 +967,6 @@
       "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
       "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.15"
       },
@@ -1017,7 +979,6 @@
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
       "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ajv": "^6.14.0",
         "debug": "^4.3.2",
@@ -1041,7 +1002,6 @@
       "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
       "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -1054,7 +1014,6 @@
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
       "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -1067,7 +1026,6 @@
       "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
       "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
@@ -1077,7 +1035,6 @@
       "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
       "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "@eslint/core": "^0.17.0",
         "levn": "^0.4.1"
@@ -1091,7 +1048,6 @@
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
       "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "@humanfs/types": "^0.15.0"
       },
@@ -1104,7 +1060,6 @@
       "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
       "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "@humanfs/core": "^0.19.2",
         "@humanfs/types": "^0.15.0",
@@ -1119,7 +1074,6 @@
       "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
       "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
       }
@@ -1129,7 +1083,6 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
       "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=12.22"
       },
@@ -1143,7 +1096,6 @@
       "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
       "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18"
       },
@@ -1152,12 +1104,37 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
         "@jridgewell/trace-mapping": "^0.3.24"
@@ -1168,7 +1145,6 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
       "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
@@ -1179,7 +1155,6 @@
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1188,26 +1163,33 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
       "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.2",
@@ -1217,7 +1199,6 @@
         "arm"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -1231,7 +1212,6 @@
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -1245,7 +1225,6 @@
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -1259,7 +1238,6 @@
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -1273,7 +1251,6 @@
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -1287,7 +1264,6 @@
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -1301,10 +1277,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1318,10 +1290,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1335,10 +1303,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1352,10 +1316,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1369,10 +1329,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1386,10 +1342,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1403,10 +1355,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1420,10 +1368,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1437,10 +1381,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1454,10 +1394,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1471,10 +1407,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1488,10 +1420,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1505,10 +1433,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1522,7 +1446,6 @@
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "openbsd"
@@ -1536,7 +1459,6 @@
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "openharmony"
@@ -1550,7 +1472,6 @@
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -1564,7 +1485,6 @@
         "ia32"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -1578,7 +1498,6 @@
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -1592,7 +1511,6 @@
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -1603,7 +1521,6 @@
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.4.tgz",
       "integrity": "sha512-Ai7+yQPxz3ddrDQzFfBKdHEVBg0w3Zl83jnjuwxnZOsnH9pGn93QHQtpU0p/8rYWxvbFZHneni6p1BSLK4DkGA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.5",
         "enhanced-resolve": "^5.19.0",
@@ -1619,7 +1536,6 @@
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.4.tgz",
       "integrity": "sha512-9El/iI069DKDSXwTvB9J4BwdO5JhRrOweGaK25taBAvBXyXqJAX+Jqdvs8r8gKpsI/1m0LeJLyQYTf/WLrBT1Q==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 20"
       },
@@ -1646,7 +1562,6 @@
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "android"
@@ -1663,7 +1578,6 @@
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -1680,7 +1594,6 @@
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -1697,7 +1610,6 @@
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
@@ -1714,7 +1626,6 @@
         "arm"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1731,10 +1642,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1751,10 +1658,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1771,10 +1674,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1791,10 +1690,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
@@ -1819,7 +1714,6 @@
         "wasm32"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "dependencies": {
         "@emnapi/core": "^1.8.1",
@@ -1841,7 +1735,6 @@
         "arm64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -1858,7 +1751,6 @@
         "x64"
       ],
       "dev": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -1872,7 +1764,6 @@
       "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.2.4.tgz",
       "integrity": "sha512-wgAVj6nUWAolAu8YFvzT2cTBIElWHkjZwFYovF+xsqKsW2ADxM/X2opxj5NsF/qVccAOjRNe8X2IdPzMsWyHTg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "@tailwindcss/node": "4.2.4",
@@ -1885,7 +1776,6 @@
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/@tanstack/devtools-event-client/-/devtools-event-client-0.4.3.tgz",
       "integrity": "sha512-OZI6QyULw0FI0wjgmeYzCIfbgPsOEzwJtCpa69XrfLMtNXLGnz3d/dIabk7frg0TmHo+Ah49w5I4KC7Tufwsvw==",
-      "license": "MIT",
       "bin": {
         "intent": "bin/intent.js"
       },
@@ -1901,7 +1791,6 @@
       "version": "1.29.1",
       "resolved": "https://registry.npmjs.org/@tanstack/form-core/-/form-core-1.29.1.tgz",
       "integrity": "sha512-NIYPO36eEu7nSWvMpbFDQaBWyVtnH/C8fsZ3/XpJUT4uOWgmxsiUvHGbTbDNIQTXAKIkhwEl0sUrqBNn2SfUnw==",
-      "license": "MIT",
       "dependencies": {
         "@tanstack/devtools-event-client": "^0.4.1",
         "@tanstack/pacer-lite": "^0.1.1",
@@ -1916,7 +1805,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@tanstack/pacer-lite/-/pacer-lite-0.1.1.tgz",
       "integrity": "sha512-y/xtNPNt/YeyoVxE/JCx+T7yjEzpezmbb+toK8DDD1P4m7Kzs5YR956+7OKexG3f8aXgC3rLZl7b1V+yNUSy5w==",
-      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -1929,7 +1817,6 @@
       "version": "5.100.5",
       "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.5.tgz",
       "integrity": "sha512-t20KrhKkf0HXzqQkPbJ5erhFesup68BAbwFgYmTrS7bxMF7O5MdmL8jUkik4thsG7Hg00fblz30h6yF1d5TxGg==",
-      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
@@ -1939,7 +1826,6 @@
       "version": "1.29.1",
       "resolved": "https://registry.npmjs.org/@tanstack/react-form/-/react-form-1.29.1.tgz",
       "integrity": "sha512-hVHk4g0phd0HxRsv2ry6Xt8BqmalT55Q3cokhJBCC1St0hcGZhgwJJbohm9atao45BPG9e55DGvtbwExqZe35g==",
-      "license": "MIT",
       "dependencies": {
         "@tanstack/form-core": "1.29.1",
         "@tanstack/react-store": "^0.9.1"
@@ -1961,7 +1847,6 @@
       "version": "5.100.5",
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.5.tgz",
       "integrity": "sha512-aNwj1mi2v2bQ9IxkyR1grLOUkv3BYWoykHy9KDyLNbjC3tsahbOHJibK+Wjtr1wRhG59/AvJhiJG5OlthaCgJA==",
-      "license": "MIT",
       "dependencies": {
         "@tanstack/query-core": "5.100.5"
       },
@@ -1977,7 +1862,6 @@
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/@tanstack/react-store/-/react-store-0.9.3.tgz",
       "integrity": "sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg==",
-      "license": "MIT",
       "dependencies": {
         "@tanstack/store": "0.9.3",
         "use-sync-external-store": "^1.6.0"
@@ -1995,7 +1879,6 @@
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/@tanstack/store/-/store-0.9.3.tgz",
       "integrity": "sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==",
-      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
@@ -2006,7 +1889,6 @@
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -2026,7 +1908,6 @@
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
       "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@adobe/css-tools": "^4.4.0",
         "aria-query": "^5.0.0",
@@ -2045,15 +1926,13 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
       "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/@testing-library/react": {
       "version": "16.3.2",
       "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
       "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.5"
       },
@@ -2081,7 +1960,6 @@
       "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
       "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=12",
         "npm": ">=6"
@@ -2094,15 +1972,13 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
       "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.20.7",
         "@babel/types": "^7.20.7",
@@ -2116,7 +1992,6 @@
       "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
       "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.0.0"
       }
@@ -2126,7 +2001,6 @@
       "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
       "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.1.0",
         "@babel/types": "^7.0.0"
@@ -2137,7 +2011,6 @@
       "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
       "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
@@ -2147,7 +2020,6 @@
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
       "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/deep-eql": "*",
         "assertion-error": "^2.0.1"
@@ -2157,29 +2029,25 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/@types/react": {
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2189,7 +2057,6 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
-      "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2199,7 +2066,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.0.tgz",
       "integrity": "sha512-HyAZtpdkgZwpq8Sz3FSUvCR4c+ScbuWa9AksK2Jweub7w4M3yTz4O11AqVJzLYjy/B9ZWPyc81I+mOdJU/bDQw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
         "@typescript-eslint/scope-manager": "8.59.0",
@@ -2228,7 +2094,6 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
       "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 4"
       }
@@ -2238,7 +2103,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.0.tgz",
       "integrity": "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.0",
         "@typescript-eslint/types": "8.59.0",
@@ -2263,7 +2127,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.0.tgz",
       "integrity": "sha512-Lw5ITrR5s5TbC19YSvlr63ZfLaJoU6vtKTHyB0GQOpX0W7d5/Ir6vUahWi/8Sps/nOukZQ0IB3SmlxZnjaKVnw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@typescript-eslint/tsconfig-utils": "^8.59.0",
         "@typescript-eslint/types": "^8.59.0",
@@ -2285,7 +2148,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.0.tgz",
       "integrity": "sha512-UzR16Ut8IpA3Mc4DbgAShlPPkVm8xXMWafXxB0BocaVRHs8ZGakAxGRskF7FId3sdk9lgGD73GSFaWmWFDE4dg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@typescript-eslint/types": "8.59.0",
         "@typescript-eslint/visitor-keys": "8.59.0"
@@ -2303,7 +2165,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.0.tgz",
       "integrity": "sha512-91Sbl3s4Kb3SybliIY6muFBmHVv+pYXfybC4Oolp3dvk8BvIE3wOPc+403CWIT7mJNkfQRGtdqghzs2+Z91Tqg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -2320,7 +2181,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.0.tgz",
       "integrity": "sha512-3TRiZaQSltGqGeNrJzzr1+8YcEobKH9rHnqIp/1psfKFmhRQDNMGP5hBufanYTGznwShzVLs3Mz+gDN7HkWfXg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@typescript-eslint/types": "8.59.0",
         "@typescript-eslint/typescript-estree": "8.59.0",
@@ -2345,7 +2205,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.0.tgz",
       "integrity": "sha512-nLzdsT1gdOgFxxxwrlNVUBzSNBEEHJ86bblmk4QAS6stfig7rcJzWKqCyxFy3YRRHXDWEkb2NralA1nOYkkm/A==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -2359,7 +2218,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.0.tgz",
       "integrity": "sha512-O9Re9P1BmBLFJyikRbQpLku/QA3/AueZNO9WePLBwQrvkixTmDe8u76B6CYUAITRl/rHawggEqUGn5QIkVRLMw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@typescript-eslint/project-service": "8.59.0",
         "@typescript-eslint/tsconfig-utils": "8.59.0",
@@ -2387,7 +2245,6 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
       "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
       }
@@ -2397,7 +2254,6 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
       "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
@@ -2410,7 +2266,6 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
       "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
-      "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.5"
       },
@@ -2426,7 +2281,6 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -2439,7 +2293,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.0.tgz",
       "integrity": "sha512-I1R/K7V07XsMJ12Oaxg/O9GfrysGTmCRhvZJBv0RE0NcULMzjqVpR5kRRQjHsz3J/bElU7HwCO7zkqL+MSUz+g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
         "@typescript-eslint/scope-manager": "8.59.0",
@@ -2463,7 +2316,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.0.tgz",
       "integrity": "sha512-/uejZt4dSere1bx12WLlPfv8GktzcaDtuJ7s42/HEZ5zGj9oxRaD4bj7qwSunXkf+pbAhFt2zjpHYUiT5lHf0Q==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@typescript-eslint/types": "8.59.0",
         "eslint-visitor-keys": "^5.0.0"
@@ -2481,7 +2333,6 @@
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
       "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
       },
@@ -2494,7 +2345,6 @@
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
       "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.28.0",
         "@babel/plugin-transform-react-jsx-self": "^7.27.1",
@@ -2510,12 +2360,44 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.4.tgz",
+      "integrity": "sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==",
+      "dev": true,
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.4",
+        "vitest": "3.2.4"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
       "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/spy": "3.2.4",
@@ -2532,7 +2414,6 @@
       "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
       "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@vitest/spy": "3.2.4",
         "estree-walker": "^3.0.3",
@@ -2559,7 +2440,6 @@
       "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
       "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "tinyrainbow": "^2.0.0"
       },
@@ -2572,7 +2452,6 @@
       "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
       "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@vitest/utils": "3.2.4",
         "pathe": "^2.0.3",
@@ -2587,7 +2466,6 @@
       "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
       "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@vitest/pretty-format": "3.2.4",
         "magic-string": "^0.30.17",
@@ -2602,7 +2480,6 @@
       "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
       "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "tinyspy": "^4.0.3"
       },
@@ -2615,7 +2492,6 @@
       "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
       "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@vitest/pretty-format": "3.2.4",
         "loupe": "^3.1.4",
@@ -2630,7 +2506,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2643,7 +2518,6 @@
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "dev": true,
-      "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
@@ -2653,7 +2527,6 @@
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 14"
       }
@@ -2663,7 +2536,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
       "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -2680,7 +2552,6 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -2690,7 +2561,6 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -2705,15 +2575,13 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
-      "license": "Python-2.0"
+      "dev": true
     },
     "node_modules/aria-query": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -2723,10 +2591,26 @@
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
       "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true
     },
     "node_modules/autoprefixer": {
       "version": "10.5.0",
@@ -2747,7 +2631,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "browserslist": "^4.28.2",
         "caniuse-lite": "^1.0.30001787",
@@ -2769,15 +2652,13 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.22",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.22.tgz",
       "integrity": "sha512-6qruVrb5rse6WylFkU0FhBKKGuecWseqdpQfhkawn6ztyk2QlfwSRjsDxMCLJrkfmfN21qvhl9ABgaMeRkuwww==",
       "dev": true,
-      "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
       },
@@ -2790,7 +2671,6 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
       "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -2815,7 +2695,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -2835,7 +2714,6 @@
       "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
       "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -2845,7 +2723,6 @@
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -2868,15 +2745,13 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ],
-      "license": "CC-BY-4.0"
+      ]
     },
     "node_modules/chai": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
       "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "assertion-error": "^2.0.1",
         "check-error": "^2.1.1",
@@ -2893,7 +2768,6 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -2910,7 +2784,6 @@
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
       "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 16"
       }
@@ -2920,7 +2793,6 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -2932,28 +2804,24 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/cookie": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
       "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
-      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -2967,7 +2835,6 @@
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -2981,15 +2848,13 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
       "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/cssstyle": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
       "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@asamuzakjp/css-color": "^3.2.0",
         "rrweb-cssom": "^0.8.0"
@@ -3002,15 +2867,13 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/daisyui": {
       "version": "5.5.19",
       "resolved": "https://registry.npmjs.org/daisyui/-/daisyui-5.5.19.tgz",
       "integrity": "sha512-pbFAkl1VCEh/MPCeclKL61I/MqRIFFhNU7yiXoDDRapXN4/qNCoMxeCCswyxEEhqL5eiTTfwHvucFtOE71C9sA==",
       "dev": true,
-      "license": "MIT",
       "funding": {
         "url": "https://github.com/saadeghi/daisyui?sponsor=1"
       }
@@ -3020,7 +2883,6 @@
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
       "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "whatwg-mimetype": "^4.0.0",
         "whatwg-url": "^14.0.0"
@@ -3034,7 +2896,6 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -3051,15 +2912,13 @@
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/deep-eql": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
       "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -3068,15 +2927,13 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -3086,7 +2943,6 @@
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
       }
@@ -3095,22 +2951,31 @@
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.344",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.344.tgz",
       "integrity": "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==",
-      "dev": true,
-      "license": "ISC"
+      "dev": true
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
     },
     "node_modules/enhanced-resolve": {
       "version": "5.21.0",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.0.tgz",
       "integrity": "sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
         "tapable": "^2.3.3"
@@ -3124,7 +2989,6 @@
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
       "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
       },
@@ -3136,8 +3000,7 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
@@ -3145,7 +3008,6 @@
       "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "MIT",
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -3186,7 +3048,6 @@
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -3196,7 +3057,6 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -3209,7 +3069,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3269,7 +3128,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz",
       "integrity": "sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -3282,7 +3140,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.4.26.tgz",
       "integrity": "sha512-1RETEylht2O6FM/MvgnyvT+8K21wLqDNg4qD51Zj3guhjt433XbnnkVttHMyaVyAFD03QSV4LPS5iE3VQmO7XQ==",
       "dev": true,
-      "license": "MIT",
       "peerDependencies": {
         "eslint": ">=8.40"
       }
@@ -3292,7 +3149,6 @@
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
       "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
@@ -3309,7 +3165,6 @@
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
       "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -3322,7 +3177,6 @@
       "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
       "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
         "acorn": "^8.15.0",
         "acorn-jsx": "^5.3.2",
@@ -3340,7 +3194,6 @@
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
       "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
         "estraverse": "^5.1.0"
       },
@@ -3353,7 +3206,6 @@
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
         "estraverse": "^5.2.0"
       },
@@ -3366,7 +3218,6 @@
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
       }
@@ -3376,7 +3227,6 @@
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
       "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
       }
@@ -3386,7 +3236,6 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3396,7 +3245,6 @@
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
       "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
       }
@@ -3405,29 +3253,25 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
       },
@@ -3445,7 +3289,6 @@
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
       "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "flat-cache": "^4.0.0"
       },
@@ -3458,7 +3301,6 @@
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
@@ -3475,7 +3317,6 @@
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
       "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "flatted": "^3.2.9",
         "keyv": "^4.5.4"
@@ -3488,15 +3329,29 @@
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "dev": true
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
       "dev": true,
-      "license": "ISC"
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/fraction.js": {
       "version": "5.3.4",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
       "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "*"
       },
@@ -3511,7 +3366,6 @@
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -3525,9 +3379,29 @@
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
       "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/glob-parent": {
@@ -3535,7 +3409,6 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
       },
@@ -3543,12 +3416,35 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/globals": {
       "version": "15.15.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
       "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -3560,15 +3456,13 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
-      "license": "ISC"
+      "dev": true
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -3578,7 +3472,6 @@
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
       "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "whatwg-encoding": "^3.1.1"
       },
@@ -3586,12 +3479,17 @@
         "node": ">=18"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.0",
         "debug": "^4.3.4"
@@ -3605,7 +3503,6 @@
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "4"
@@ -3619,7 +3516,6 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -3632,7 +3528,6 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 4"
       }
@@ -3642,7 +3537,6 @@
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
       "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -3659,7 +3553,6 @@
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
       }
@@ -3669,7 +3562,6 @@
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
       "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -3679,9 +3571,17 @@
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
@@ -3689,7 +3589,6 @@
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -3701,22 +3600,84 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
       "dev": true,
-      "license": "ISC"
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
     },
     "node_modules/jiti": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -3725,15 +3686,13 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/js-yaml": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
       "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -3746,7 +3705,6 @@
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -3786,7 +3744,6 @@
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
       "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
       },
@@ -3798,29 +3755,25 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "json5": "lib/cli.js"
       },
@@ -3833,7 +3786,6 @@
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
       }
@@ -3843,7 +3795,6 @@
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
@@ -3857,7 +3808,6 @@
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
       "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
-      "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
@@ -3890,7 +3840,6 @@
         "arm64"
       ],
       "dev": true,
-      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "android"
@@ -3911,7 +3860,6 @@
         "arm64"
       ],
       "dev": true,
-      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "darwin"
@@ -3932,7 +3880,6 @@
         "x64"
       ],
       "dev": true,
-      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "darwin"
@@ -3953,7 +3900,6 @@
         "x64"
       ],
       "dev": true,
-      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "freebsd"
@@ -3974,7 +3920,6 @@
         "arm"
       ],
       "dev": true,
-      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -3995,10 +3940,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -4019,10 +3960,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -4043,10 +3980,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
-      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -4067,10 +4000,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
-      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -4091,7 +4020,6 @@
         "arm64"
       ],
       "dev": true,
-      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "win32"
@@ -4112,7 +4040,6 @@
         "x64"
       ],
       "dev": true,
-      "license": "MPL-2.0",
       "optional": true,
       "os": [
         "win32"
@@ -4130,7 +4057,6 @@
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "p-locate": "^5.0.0"
       },
@@ -4145,22 +4071,19 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/loupe": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
       "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
       "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
       }
@@ -4170,7 +4093,6 @@
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -4180,9 +4102,46 @@
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
       "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/min-indent": {
@@ -4190,7 +4149,6 @@
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -4200,7 +4158,6 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
       "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -4208,12 +4165,20 @@
         "node": "*"
       }
     },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -4226,7 +4191,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -4238,29 +4202,25 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/node-releases": {
       "version": "2.0.38",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
       "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/nwsapi": {
       "version": "2.2.23",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
       "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
       "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
@@ -4278,7 +4238,6 @@
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
       },
@@ -4294,7 +4253,6 @@
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "p-limit": "^3.0.2"
       },
@@ -4305,12 +4263,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
       },
@@ -4323,7 +4286,6 @@
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
       "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "entities": "^6.0.0"
       },
@@ -4336,7 +4298,6 @@
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -4346,24 +4307,43 @@
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true
     },
     "node_modules/pathe": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/pathval": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
       "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 14.16"
       }
@@ -4372,15 +4352,13 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
-      "license": "ISC"
+      "dev": true
     },
     "node_modules/picomatch": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -4389,9 +4367,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "version": "8.5.11",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.11.tgz",
+      "integrity": "sha512-5dDj8+lmvA8XB78SmzGI8NlQoksv7IfutGWeVZxiixHbO+p4LDPT3wuG/D9sM/wrjZZ9I+Siy/e117vbFPxSZg==",
       "dev": true,
       "funding": [
         {
@@ -4407,7 +4385,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -4421,15 +4398,13 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -4439,7 +4414,6 @@
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -4454,7 +4428,6 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -4467,7 +4440,6 @@
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -4476,7 +4448,6 @@
       "version": "19.2.5",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4485,7 +4456,6 @@
       "version": "19.2.5",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
-      "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -4497,15 +4467,13 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
       "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4514,7 +4482,6 @@
       "version": "7.14.2",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.2.tgz",
       "integrity": "sha512-yCqNne6I8IB6rVCH7XUvlBK7/QKyqypBFGv+8dj4QBFJiiRX+FG7/nkdAvGElyvVZ/HQP5N19wzteuTARXi5Gw==",
-      "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
         "set-cookie-parser": "^2.6.0"
@@ -4536,7 +4503,6 @@
       "version": "7.14.2",
       "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.14.2.tgz",
       "integrity": "sha512-YZcM5ES8jJSM+KrJ9BdvHHqlnGTg5tH3sC5ChFRj4inosKctdyzBDhOyyHdGk597q2OT6NTrCA1OvB/YDwfekQ==",
-      "license": "MIT",
       "dependencies": {
         "react-router": "7.14.2"
       },
@@ -4553,7 +4519,6 @@
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
       "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "indent-string": "^4.0.0",
         "strip-indent": "^3.0.0"
@@ -4567,7 +4532,6 @@
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=4"
       }
@@ -4577,7 +4541,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
       "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -4621,22 +4584,19 @@
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
       "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
       "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "xmlchars": "^2.2.0"
       },
@@ -4647,15 +4607,13 @@
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
-      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "license": "MIT"
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="
     },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -4663,15 +4621,13 @@
     "node_modules/set-cookie-parser": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
-      "license": "MIT"
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
@@ -4684,7 +4640,6 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -4693,15 +4648,25 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
       "dev": true,
-      "license": "ISC"
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4710,22 +4675,109 @@
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/std-env": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
       "dev": true,
-      "license": "MIT"
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
     },
     "node_modules/strip-indent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
       "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "min-indent": "^1.0.0"
       },
@@ -4738,7 +4790,6 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       },
@@ -4751,7 +4802,6 @@
       "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
       "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "js-tokens": "^9.0.1"
       },
@@ -4763,15 +4813,13 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -4783,22 +4831,19 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/tailwindcss": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.4.tgz",
       "integrity": "sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/tapable": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
       "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6"
       },
@@ -4807,26 +4852,73 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/test-exclude/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
       "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/tinyexec": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
       "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
       "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
         "picomatch": "^4.0.4"
@@ -4843,7 +4935,6 @@
       "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
       "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^18.0.0 || >=20.0.0"
       }
@@ -4853,7 +4944,6 @@
       "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
       "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -4863,7 +4953,6 @@
       "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
       "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -4873,7 +4962,6 @@
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
       "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "tldts-core": "^6.1.86"
       },
@@ -4885,15 +4973,13 @@
       "version": "6.1.86",
       "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
       "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/tough-cookie": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
       "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
         "tldts": "^6.1.32"
       },
@@ -4906,7 +4992,6 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
       "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "punycode": "^2.3.1"
       },
@@ -4919,7 +5004,6 @@
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
       "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=18.12"
       },
@@ -4932,7 +5016,6 @@
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1"
       },
@@ -4945,7 +5028,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true,
-      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4959,7 +5041,6 @@
       "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.0.tgz",
       "integrity": "sha512-BU3ONW9X+v90EcCH9ZS6LMackcVtxRLlI3XrYyqZIwVSHIk7Qf7bFw1z0M9Q0IUxhTMZCf8piY9hTYaNEIASrw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "8.59.0",
         "@typescript-eslint/parser": "8.59.0",
@@ -4997,7 +5078,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "escalade": "^3.2.0",
         "picocolors": "^1.1.1"
@@ -5014,7 +5094,6 @@
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
       }
@@ -5023,7 +5102,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
       "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
-      "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
@@ -5033,7 +5111,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
       "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -5108,7 +5185,6 @@
       "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
       "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "cac": "^6.7.14",
         "debug": "^4.4.1",
@@ -5131,7 +5207,6 @@
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -5204,7 +5279,6 @@
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
       "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "xml-name-validator": "^5.0.0"
       },
@@ -5217,7 +5291,6 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
       "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
       "dev": true,
-      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
       }
@@ -5228,7 +5301,6 @@
       "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
       "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "iconv-lite": "0.6.3"
       },
@@ -5241,7 +5313,6 @@
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
       "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=18"
       }
@@ -5251,7 +5322,6 @@
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
       "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "tr46": "^5.1.0",
         "webidl-conversions": "^7.0.0"
@@ -5265,7 +5335,6 @@
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
       },
@@ -5281,7 +5350,6 @@
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
       "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "siginfo": "^2.0.0",
         "stackback": "0.0.2"
@@ -5298,9 +5366,87 @@
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/ws": {
@@ -5308,7 +5454,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
       "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -5330,7 +5475,6 @@
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
       "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
       }
@@ -5339,22 +5483,19 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-      "dev": true,
-      "license": "MIT"
+      "dev": true
     },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-      "dev": true,
-      "license": "ISC"
+      "dev": true
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,6 +29,7 @@
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.4",
+    "@vitest/coverage-v8": "^3.2.4",
     "autoprefixer": "^10.4.20",
     "daisyui": "^5.0.0",
     "eslint": "^9.15.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,8 @@
     "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "postinstall": "npm rebuild rollup"
   },
   "dependencies": {
     "@tanstack/react-form": "^1.0.0",

--- a/frontend/src/components/AddBillForm.test.tsx
+++ b/frontend/src/components/AddBillForm.test.tsx
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode } from "react";
+import { AddBillForm } from "./AddBillForm";
+import { ToastProvider } from "../contexts/ToastContext";
+import type { BillTemplate } from "../types";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+const mockTemplates: BillTemplate[] = [
+  {
+    id: 1,
+    name: "Rent",
+    default_amount: "1500.00",
+    due_day_of_month: 1,
+    is_recurring: true,
+    category_id: null,
+    notes: null,
+    created_at: "2026-04-01T00:00:00Z",
+    updated_at: "2026-04-01T00:00:00Z",
+  },
+];
+
+function jsonResponse(status: number, body: unknown) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  };
+}
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <ToastProvider>{children}</ToastProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+async function renderWithTemplates(templates: BillTemplate[]) {
+  mockFetch.mockResolvedValueOnce(jsonResponse(200, templates));
+  render(<AddBillForm payPeriodId={1} />, { wrapper: createWrapper() });
+  // Wait for the templates fetch to settle
+  await waitFor(() => {
+    expect(screen.getByPlaceholderText("Bill name")).toBeInTheDocument();
+  });
+}
+
+describe("AddBillForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the core fields", async () => {
+    await renderWithTemplates([]);
+    expect(screen.getByPlaceholderText("Bill name")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("0.00")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Add Bill/i })).toBeInTheDocument();
+  });
+
+  it("does not show the template selector when no templates exist", async () => {
+    await renderWithTemplates([]);
+    expect(screen.queryByText("Template")).not.toBeInTheDocument();
+  });
+
+  it("shows the template selector when templates exist", async () => {
+    await renderWithTemplates(mockTemplates);
+    // Wait for the async useBillTemplates query to populate the select
+    expect(await screen.findByText("Template")).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Rent" })).toBeInTheDocument();
+  });
+
+  it("populates name and amount when a template is selected", async () => {
+    await renderWithTemplates(mockTemplates);
+    const select = (await screen.findByRole("combobox")) as HTMLSelectElement;
+    fireEvent.change(select, { target: { value: "1" } });
+
+    expect((screen.getByPlaceholderText("Bill name") as HTMLInputElement).value).toBe(
+      "Rent"
+    );
+    expect((screen.getByPlaceholderText("0.00") as HTMLInputElement).value).toBe(
+      "1500.00"
+    );
+  });
+
+  it("submits a POST to the pay period's bills endpoint", async () => {
+    await renderWithTemplates([]);
+    fireEvent.change(screen.getByPlaceholderText("Bill name"), {
+      target: { value: "Internet" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("0.00"), {
+      target: { value: "75" },
+    });
+
+    mockFetch.mockResolvedValueOnce(jsonResponse(201, { id: 1, name: "Internet" }));
+    mockFetch.mockResolvedValue(jsonResponse(200, []));
+
+    fireEvent.click(screen.getByRole("button", { name: /Add Bill/i }));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/pay-periods/1/bills",
+        expect.objectContaining({
+          method: "POST",
+          body: expect.stringContaining('"name":"Internet"'),
+        })
+      );
+    });
+  });
+
+  it("does not submit when name or amount is empty", async () => {
+    await renderWithTemplates([]);
+    const callsBefore = mockFetch.mock.calls.length;
+    fireEvent.click(screen.getByRole("button", { name: /Add Bill/i }));
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mockFetch.mock.calls.length).toBe(callsBefore);
+  });
+});

--- a/frontend/src/components/AddSpendingForm.test.tsx
+++ b/frontend/src/components/AddSpendingForm.test.tsx
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode } from "react";
+import { AddSpendingForm } from "./AddSpendingForm";
+import { ToastProvider } from "../contexts/ToastContext";
+import type { Category } from "../types";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+const mockCategories: Category[] = [
+  {
+    id: 5,
+    name: "Food",
+    description: null,
+    color: "#f59e0b",
+    created_at: "2026-04-01T00:00:00Z",
+    updated_at: "2026-04-01T00:00:00Z",
+  },
+];
+
+function jsonResponse(status: number, body: unknown) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  };
+}
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <ToastProvider>{children}</ToastProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+async function renderWithCategories(categories: Category[]) {
+  mockFetch.mockResolvedValueOnce(jsonResponse(200, categories));
+  render(<AddSpendingForm payPeriodId={2} />, { wrapper: createWrapper() });
+  await waitFor(() => {
+    expect(screen.getByPlaceholderText("What did you buy?")).toBeInTheDocument();
+  });
+}
+
+describe("AddSpendingForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders all fields across both rows", async () => {
+    await renderWithCategories([]);
+    expect(screen.getByPlaceholderText("What did you buy?")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("0.00")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Optional notes")).toBeInTheDocument();
+    expect(screen.getByRole("combobox")).toBeInTheDocument(); // Category select
+    expect(screen.getByRole("button", { name: /Add Spending/i })).toBeInTheDocument();
+  });
+
+  it("includes categories in the dropdown when present", async () => {
+    await renderWithCategories(mockCategories);
+    // Wait for the async useCategories query to populate the dropdown
+    expect(await screen.findByRole("option", { name: "Food" })).toBeInTheDocument();
+  });
+
+  it("submits a POST with description, amount, and date", async () => {
+    await renderWithCategories([]);
+
+    fireEvent.change(screen.getByPlaceholderText("What did you buy?"), {
+      target: { value: "Coffee" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("0.00"), {
+      target: { value: "4.50" },
+    });
+
+    mockFetch.mockResolvedValueOnce(jsonResponse(201, { id: 1 }));
+    mockFetch.mockResolvedValue(jsonResponse(200, []));
+
+    fireEvent.click(screen.getByRole("button", { name: /Add Spending/i }));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/pay-periods/2/spending",
+        expect.objectContaining({
+          method: "POST",
+          body: expect.stringContaining('"description":"Coffee"'),
+        })
+      );
+    });
+  });
+
+  it("includes category_id in the payload when one is selected", async () => {
+    await renderWithCategories(mockCategories);
+
+    fireEvent.change(screen.getByPlaceholderText("What did you buy?"), {
+      target: { value: "Lunch" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("0.00"), {
+      target: { value: "12" },
+    });
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "5" } });
+
+    mockFetch.mockResolvedValueOnce(jsonResponse(201, { id: 1 }));
+    mockFetch.mockResolvedValue(jsonResponse(200, []));
+
+    fireEvent.click(screen.getByRole("button", { name: /Add Spending/i }));
+
+    await waitFor(() => {
+      const call = mockFetch.mock.calls.find(
+        (c) => c[0] === "/api/pay-periods/2/spending"
+      );
+      expect(call?.[1]?.body).toContain('"category_id":5');
+    });
+  });
+
+  it("does not submit when description is missing", async () => {
+    await renderWithCategories([]);
+    const callsBefore = mockFetch.mock.calls.length;
+    fireEvent.click(screen.getByRole("button", { name: /Add Spending/i }));
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mockFetch.mock.calls.length).toBe(callsBefore);
+  });
+});

--- a/frontend/src/components/AdditionalIncomeCard.test.tsx
+++ b/frontend/src/components/AdditionalIncomeCard.test.tsx
@@ -1,0 +1,163 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode } from "react";
+import { AdditionalIncomeCard } from "./AdditionalIncomeCard";
+import { ToastProvider } from "../contexts/ToastContext";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+function jsonResponse(status: number, body: unknown) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  };
+}
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <ToastProvider>{children}</ToastProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+function renderCard(value: string | null, description: string | null = null) {
+  return render(
+    <AdditionalIncomeCard
+      payPeriodId={3}
+      currentValue={value}
+      currentDescription={description}
+    />,
+    { wrapper: createWrapper() }
+  );
+}
+
+describe("AdditionalIncomeCard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("display mode", () => {
+    it("shows $0.00 when currentValue is null", () => {
+      renderCard(null);
+      expect(screen.getByText("$0.00")).toBeInTheDocument();
+    });
+
+    it("formats currentValue as USD", () => {
+      renderCard("123.45");
+      expect(screen.getByText("$123.45")).toBeInTheDocument();
+    });
+
+    it("shows the description when provided", () => {
+      renderCard("100", "Side gig");
+      expect(screen.getByText("Side gig")).toBeInTheDocument();
+    });
+
+    it("does not render a description paragraph when null", () => {
+      renderCard("100", null);
+      // No paragraph child should exist next to the value
+      expect(screen.queryByText(/^(?!Additional Income).+/, { selector: "p" })).toBeNull();
+    });
+  });
+
+  describe("edit mode", () => {
+    it("clicking Edit reveals the value and description inputs", () => {
+      renderCard("100", "Bonus");
+      fireEvent.click(screen.getByRole("button", { name: /Edit/i }));
+      expect(screen.getByDisplayValue("100")).toBeInTheDocument();
+      expect(screen.getByDisplayValue("Bonus")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /Save/i })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /Cancel/i })).toBeInTheDocument();
+    });
+
+    it("Save fires a PUT and exits edit mode", async () => {
+      renderCard("100", "Old desc");
+      fireEvent.click(screen.getByRole("button", { name: /Edit/i }));
+
+      fireEvent.change(screen.getByDisplayValue("100"), { target: { value: "200" } });
+      fireEvent.change(screen.getByDisplayValue("Old desc"), {
+        target: { value: "New desc" },
+      });
+
+      mockFetch.mockResolvedValueOnce(jsonResponse(200, {}));
+      mockFetch.mockResolvedValue(jsonResponse(200, {}));
+
+      fireEvent.click(screen.getByRole("button", { name: /Save/i }));
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledWith(
+          "/api/pay-periods/3",
+          expect.objectContaining({
+            method: "PUT",
+            body: expect.stringContaining('"additional_income":200'),
+          })
+        );
+      });
+      // Save call should have the description too
+      const putCall = mockFetch.mock.calls.find(
+        (c) => c[0] === "/api/pay-periods/3"
+      );
+      expect(putCall?.[1]?.body).toContain('"additional_income_description":"New desc"');
+    });
+
+    it("Save with 0 sends null for additional_income (clears the value)", async () => {
+      renderCard("100");
+      fireEvent.click(screen.getByRole("button", { name: /Edit/i }));
+      fireEvent.change(screen.getByDisplayValue("100"), { target: { value: "0" } });
+
+      mockFetch.mockResolvedValueOnce(jsonResponse(200, {}));
+      mockFetch.mockResolvedValue(jsonResponse(200, {}));
+
+      fireEvent.click(screen.getByRole("button", { name: /Save/i }));
+
+      await waitFor(() => {
+        const putCall = mockFetch.mock.calls.find(
+          (c) => c[0] === "/api/pay-periods/3"
+        );
+        expect(putCall?.[1]?.body).toContain('"additional_income":null');
+      });
+    });
+
+    it("Save with a negative value does not PUT (early return)", async () => {
+      // The toast itself is rendered by ToastContainer (not in our wrapper),
+      // so we verify the behavior: the mutation never fires.
+      renderCard("100");
+      fireEvent.click(screen.getByRole("button", { name: /Edit/i }));
+      fireEvent.change(screen.getByDisplayValue("100"), { target: { value: "-5" } });
+
+      const callsBefore = mockFetch.mock.calls.length;
+      fireEvent.click(screen.getByRole("button", { name: /Save/i }));
+
+      // Give any potential async mutation time to fire — it shouldn't
+      await new Promise((r) => setTimeout(r, 50));
+      expect(mockFetch.mock.calls.length).toBe(callsBefore);
+      // We're still in edit mode (Save did not succeed)
+      expect(screen.getByRole("button", { name: /Save/i })).toBeInTheDocument();
+    });
+
+    it("Cancel exits edit mode without firing a PUT", () => {
+      renderCard("100", "Old desc");
+      fireEvent.click(screen.getByRole("button", { name: /Edit/i }));
+      fireEvent.change(screen.getByDisplayValue("100"), { target: { value: "999" } });
+
+      const callsBefore = mockFetch.mock.calls.length;
+      fireEvent.click(screen.getByRole("button", { name: /Cancel/i }));
+
+      // Back in display mode — value reverts
+      expect(screen.queryByDisplayValue("999")).not.toBeInTheDocument();
+      expect(screen.getByText("$100.00")).toBeInTheDocument();
+      expect(mockFetch.mock.calls.length).toBe(callsBefore);
+    });
+  });
+});

--- a/frontend/src/components/BillsTable.test.tsx
+++ b/frontend/src/components/BillsTable.test.tsx
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode } from "react";
+import { BillsTable } from "./BillsTable";
+import { ToastProvider } from "../contexts/ToastContext";
+import type { PayPeriodBill } from "../types";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+const baseBill: PayPeriodBill = {
+  id: 1,
+  pay_period_id: 5,
+  bill_template_id: null,
+  name: "Rent",
+  amount: "1500.00",
+  due_date: "2026-04-01",
+  is_paid: false,
+  paid_date: null,
+  notes: null,
+  created_at: "2026-04-01T00:00:00Z",
+  updated_at: "2026-04-01T00:00:00Z",
+};
+
+function jsonResponse(status: number, body: unknown) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  };
+}
+
+function noContentResponse() {
+  return { ok: true, status: 204 };
+}
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <ToastProvider>{children}</ToastProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+describe("BillsTable", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows the empty-state message when there are no bills", () => {
+    render(<BillsTable bills={[]} payPeriodId={5} />, { wrapper: createWrapper() });
+    expect(screen.getByText(/No bills for this pay period/)).toBeInTheDocument();
+  });
+
+  it("renders a row per bill with formatted amount", () => {
+    render(<BillsTable bills={[baseBill]} payPeriodId={5} />, {
+      wrapper: createWrapper(),
+    });
+    expect(screen.getByText("Rent")).toBeInTheDocument();
+    expect(screen.getAllByText("$1,500.00").length).toBeGreaterThan(0);
+  });
+
+  it("shows a footer total summing all bills", () => {
+    const bills = [
+      baseBill,
+      { ...baseBill, id: 2, name: "Internet", amount: "75.00" },
+    ];
+    render(<BillsTable bills={bills} payPeriodId={5} />, { wrapper: createWrapper() });
+    // Footer total = 1500 + 75 = 1575
+    expect(screen.getByText("$1,575.00")).toBeInTheDocument();
+  });
+
+  it("toggling the paid checkbox PUTs is_paid=true with today's date", async () => {
+    render(<BillsTable bills={[baseBill]} payPeriodId={5} />, {
+      wrapper: createWrapper(),
+    });
+
+    mockFetch.mockResolvedValueOnce(jsonResponse(200, { ...baseBill, is_paid: true }));
+    mockFetch.mockResolvedValue(jsonResponse(200, []));
+
+    fireEvent.click(screen.getByRole("checkbox"));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/bills/1",
+        expect.objectContaining({
+          method: "PUT",
+          body: expect.stringContaining('"is_paid":true'),
+        })
+      );
+    });
+  });
+
+  it("Edit puts the row into edit mode with current values", () => {
+    render(<BillsTable bills={[baseBill]} payPeriodId={5} />, {
+      wrapper: createWrapper(),
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Edit/i }));
+    expect(screen.getByDisplayValue("Rent")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("1500.00")).toBeInTheDocument();
+  });
+
+  it("Save in edit mode PUTs the new values", async () => {
+    render(<BillsTable bills={[baseBill]} payPeriodId={5} />, {
+      wrapper: createWrapper(),
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Edit/i }));
+
+    fireEvent.change(screen.getByDisplayValue("Rent"), {
+      target: { value: "Mortgage" },
+    });
+    fireEvent.change(screen.getByDisplayValue("1500.00"), {
+      target: { value: "1600" },
+    });
+
+    mockFetch.mockResolvedValueOnce(jsonResponse(200, { ...baseBill, name: "Mortgage" }));
+    mockFetch.mockResolvedValue(jsonResponse(200, []));
+
+    const editingRow = screen.getByDisplayValue("Mortgage").closest("tr")!;
+    fireEvent.click(within(editingRow).getByRole("button", { name: /Save/i }));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/bills/1",
+        expect.objectContaining({
+          method: "PUT",
+          body: expect.stringContaining('"name":"Mortgage"'),
+        })
+      );
+    });
+  });
+
+  it("Cancel exits edit mode without firing a PUT", () => {
+    render(<BillsTable bills={[baseBill]} payPeriodId={5} />, {
+      wrapper: createWrapper(),
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Edit/i }));
+    const editingRow = screen.getByDisplayValue("Rent").closest("tr")!;
+
+    const before = mockFetch.mock.calls.length;
+    fireEvent.click(within(editingRow).getByRole("button", { name: /Cancel/i }));
+
+    expect(screen.queryByDisplayValue("Rent")).not.toBeInTheDocument();
+    expect(mockFetch.mock.calls.length).toBe(before);
+  });
+
+  it("Delete confirms then DELETEs", async () => {
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+    render(<BillsTable bills={[baseBill]} payPeriodId={5} />, {
+      wrapper: createWrapper(),
+    });
+
+    mockFetch.mockResolvedValueOnce(noContentResponse());
+    mockFetch.mockResolvedValue(jsonResponse(200, []));
+
+    fireEvent.click(screen.getByRole("button", { name: /Delete/i }));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/bills/1",
+        expect.objectContaining({ method: "DELETE" })
+      );
+    });
+  });
+
+  it("Delete does nothing when the user cancels the confirm dialog", () => {
+    vi.spyOn(window, "confirm").mockReturnValue(false);
+    render(<BillsTable bills={[baseBill]} payPeriodId={5} />, {
+      wrapper: createWrapper(),
+    });
+
+    const before = mockFetch.mock.calls.length;
+    fireEvent.click(screen.getByRole("button", { name: /Delete/i }));
+    expect(mockFetch.mock.calls.length).toBe(before);
+  });
+});

--- a/frontend/src/components/CategoryManagement.test.tsx
+++ b/frontend/src/components/CategoryManagement.test.tsx
@@ -1,0 +1,331 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode } from "react";
+import { CategoryManagement } from "./CategoryManagement";
+import { ToastProvider } from "../contexts/ToastContext";
+import type { Category } from "../types";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+const mockCategories: Category[] = [
+  {
+    id: 1,
+    name: "Food",
+    description: "Food and dining",
+    color: "#f59e0b",
+    created_at: "2026-04-01T00:00:00Z",
+    updated_at: "2026-04-01T00:00:00Z",
+  },
+  {
+    id: 2,
+    name: "Travel",
+    description: null,
+    color: "#3b82f6",
+    created_at: "2026-04-01T00:00:00Z",
+    updated_at: "2026-04-01T00:00:00Z",
+  },
+];
+
+function jsonResponse(status: number, body: unknown) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  };
+}
+
+function noContentResponse() {
+  return { ok: true, status: 204 };
+}
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <ToastProvider>{children}</ToastProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+async function renderWithCategories(categories: Category[]) {
+  mockFetch.mockResolvedValueOnce(jsonResponse(200, categories));
+  render(<CategoryManagement />, { wrapper: createWrapper() });
+  // Wait until the initial GET resolves and the table appears
+  if (categories.length > 0) {
+    await screen.findByText(categories[0].name);
+  } else {
+    await screen.findByText(/No categories yet/);
+  }
+}
+
+describe("CategoryManagement", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("list rendering", () => {
+    it("shows a spinner while loading", () => {
+      // Pending fetch — never resolves during this test
+      mockFetch.mockReturnValueOnce(new Promise(() => {}));
+      const { container } = render(<CategoryManagement />, {
+        wrapper: createWrapper(),
+      });
+      expect(container.querySelector(".loading-spinner")).toBeInTheDocument();
+    });
+
+    it("renders the empty state when no categories exist", async () => {
+      await renderWithCategories([]);
+      expect(screen.getByText(/No categories yet/)).toBeInTheDocument();
+    });
+
+    it("renders categories with name, description, and color swatch", async () => {
+      await renderWithCategories(mockCategories);
+
+      expect(screen.getByText("Food")).toBeInTheDocument();
+      expect(screen.getByText("Food and dining")).toBeInTheDocument();
+      expect(screen.getByText("Travel")).toBeInTheDocument();
+
+      // Color swatch uses inline style. Find by title attribute (matches the hex color).
+      const foodSwatch = screen.getByTitle("#f59e0b");
+      expect(foodSwatch).toHaveStyle({ backgroundColor: "#f59e0b" });
+    });
+  });
+
+  describe("create", () => {
+    it("submits a POST when adding a category", async () => {
+      await renderWithCategories([]);
+
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse(201, {
+          ...mockCategories[0],
+          id: 99,
+          name: "Groceries",
+        })
+      );
+      // After mutation success the list is invalidated and refetched
+      mockFetch.mockResolvedValueOnce(jsonResponse(200, mockCategories));
+
+      const nameInput = screen.getByPlaceholderText("e.g., Groceries");
+      fireEvent.change(nameInput, { target: { value: "Groceries" } });
+      fireEvent.click(screen.getByRole("button", { name: /Add Category/i }));
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledWith(
+          "/api/categories",
+          expect.objectContaining({
+            method: "POST",
+            body: expect.stringContaining('"name":"Groceries"'),
+          })
+        );
+      });
+    });
+
+    it("does not submit when name is empty", async () => {
+      await renderWithCategories([]);
+
+      const initialCallCount = mockFetch.mock.calls.length;
+      fireEvent.click(screen.getByRole("button", { name: /Add Category/i }));
+
+      // Give any potential mutation a tick to fire — it shouldn't
+      await new Promise((r) => setTimeout(r, 0));
+      expect(mockFetch.mock.calls.length).toBe(initialCallCount);
+    });
+  });
+
+  describe("inline edit", () => {
+    it("toggles into edit mode when Edit is clicked", async () => {
+      await renderWithCategories(mockCategories);
+
+      const foodRow = screen.getByText("Food").closest("tr")!;
+      fireEvent.click(within(foodRow).getByRole("button", { name: /Edit/i }));
+
+      // Now the row contains a Save and Cancel button
+      const editingRow = screen.getByDisplayValue("Food").closest("tr")!;
+      expect(within(editingRow).getByRole("button", { name: /Save/i })).toBeInTheDocument();
+      expect(within(editingRow).getByRole("button", { name: /Cancel/i })).toBeInTheDocument();
+    });
+
+    it("submits a PUT with edited values on Save", async () => {
+      await renderWithCategories(mockCategories);
+
+      const foodRow = screen.getByText("Food").closest("tr")!;
+      fireEvent.click(within(foodRow).getByRole("button", { name: /Edit/i }));
+
+      const nameInput = screen.getByDisplayValue("Food");
+      fireEvent.change(nameInput, { target: { value: "Dining Out" } });
+
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse(200, { ...mockCategories[0], name: "Dining Out" })
+      );
+      // Refetch after mutation success
+      mockFetch.mockResolvedValueOnce(jsonResponse(200, mockCategories));
+
+      const editingRow = nameInput.closest("tr")!;
+      fireEvent.click(within(editingRow).getByRole("button", { name: /Save/i }));
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledWith(
+          "/api/categories/1",
+          expect.objectContaining({
+            method: "PUT",
+            body: expect.stringContaining('"name":"Dining Out"'),
+          })
+        );
+      });
+    });
+
+    it("Cancel exits edit mode without firing a PUT", async () => {
+      await renderWithCategories(mockCategories);
+
+      const foodRow = screen.getByText("Food").closest("tr")!;
+      fireEvent.click(within(foodRow).getByRole("button", { name: /Edit/i }));
+
+      const editingRow = screen.getByDisplayValue("Food").closest("tr")!;
+      const callsBefore = mockFetch.mock.calls.length;
+
+      fireEvent.click(within(editingRow).getByRole("button", { name: /Cancel/i }));
+
+      // Display row is back (no input)
+      expect(screen.queryByDisplayValue("Food")).not.toBeInTheDocument();
+      expect(mockFetch.mock.calls.length).toBe(callsBefore);
+    });
+  });
+
+  describe("delete", () => {
+    it("deletes immediately when category is unused (204)", async () => {
+      await renderWithCategories(mockCategories);
+
+      mockFetch.mockResolvedValueOnce(noContentResponse());
+      // Multiple invalidations fire on delete success (categories + bills/spending)
+      mockFetch.mockResolvedValue(jsonResponse(200, []));
+
+      const foodRow = screen.getByText("Food").closest("tr")!;
+      fireEvent.click(within(foodRow).getByRole("button", { name: /Delete/i }));
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledWith(
+          "/api/categories/1",
+          expect.objectContaining({ method: "DELETE" })
+        );
+      });
+      // No confirmation modal should have appeared
+      expect(screen.queryByText(/Category in use/)).not.toBeInTheDocument();
+    });
+
+    it("opens confirmation modal with usage counts on 409", async () => {
+      await renderWithCategories(mockCategories);
+
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse(409, {
+          error: "in_use",
+          bill_templates: 2,
+          spending_entries: 5,
+        })
+      );
+
+      const foodRow = screen.getByText("Food").closest("tr")!;
+      fireEvent.click(within(foodRow).getByRole("button", { name: /Delete/i }));
+
+      await screen.findByText(/Category in use/);
+      expect(screen.getByText(/2 bill templates and 5 spending entries/)).toBeInTheDocument();
+      expect(screen.getByText(/leave those items/)).toBeInTheDocument();
+    });
+
+    it("singularizes usage counts of 1", async () => {
+      await renderWithCategories(mockCategories);
+
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse(409, {
+          error: "in_use",
+          bill_templates: 1,
+          spending_entries: 1,
+        })
+      );
+
+      const foodRow = screen.getByText("Food").closest("tr")!;
+      fireEvent.click(within(foodRow).getByRole("button", { name: /Delete/i }));
+
+      await screen.findByText(/1 bill template and 1 spending entry/);
+    });
+
+    it("omits zero-count categories from the usage message", async () => {
+      await renderWithCategories(mockCategories);
+
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse(409, {
+          error: "in_use",
+          bill_templates: 0,
+          spending_entries: 3,
+        })
+      );
+
+      const foodRow = screen.getByText("Food").closest("tr")!;
+      fireEvent.click(within(foodRow).getByRole("button", { name: /Delete/i }));
+
+      await screen.findByText(/3 spending entries/);
+      expect(screen.queryByText(/bill template/)).not.toBeInTheDocument();
+    });
+
+    it("calls DELETE with force=true when 'Delete anyway' is confirmed", async () => {
+      await renderWithCategories(mockCategories);
+
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse(409, {
+          error: "in_use",
+          bill_templates: 1,
+          spending_entries: 0,
+        })
+      );
+
+      const foodRow = screen.getByText("Food").closest("tr")!;
+      fireEvent.click(within(foodRow).getByRole("button", { name: /Delete/i }));
+
+      await screen.findByText(/Category in use/);
+
+      mockFetch.mockResolvedValueOnce(noContentResponse());
+      mockFetch.mockResolvedValue(jsonResponse(200, []));
+
+      fireEvent.click(screen.getByRole("button", { name: /Delete anyway/i }));
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledWith(
+          "/api/categories/1?force=true",
+          expect.objectContaining({ method: "DELETE" })
+        );
+      });
+    });
+
+    it("Cancel closes modal without firing the force delete", async () => {
+      await renderWithCategories(mockCategories);
+
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse(409, {
+          error: "in_use",
+          bill_templates: 1,
+          spending_entries: 0,
+        })
+      );
+
+      const foodRow = screen.getByText("Food").closest("tr")!;
+      fireEvent.click(within(foodRow).getByRole("button", { name: /Delete/i }));
+
+      await screen.findByText(/Category in use/);
+      const callsBefore = mockFetch.mock.calls.length;
+
+      fireEvent.click(screen.getByRole("button", { name: /^Cancel$/i }));
+
+      expect(screen.queryByText(/Category in use/)).not.toBeInTheDocument();
+      // Modal close shouldn't trigger another fetch
+      expect(mockFetch.mock.calls.length).toBe(callsBefore);
+    });
+  });
+});

--- a/frontend/src/components/ErrorBoundary.test.tsx
+++ b/frontend/src/components/ErrorBoundary.test.tsx
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ErrorBoundary } from "./ErrorBoundary";
+
+function Boom({ message = "kaboom" }: { message?: string }): React.ReactElement {
+  throw new Error(message);
+}
+
+describe("ErrorBoundary", () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    // React logs the caught error to console.error — silence for cleaner test output
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("renders children when no error is thrown", () => {
+    render(
+      <ErrorBoundary>
+        <div>Happy path</div>
+      </ErrorBoundary>
+    );
+    expect(screen.getByText("Happy path")).toBeInTheDocument();
+  });
+
+  it("renders the fallback UI when a child throws", () => {
+    render(
+      <ErrorBoundary>
+        <Boom message="something exploded" />
+      </ErrorBoundary>
+    );
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+    expect(screen.getByText("something exploded")).toBeInTheDocument();
+  });
+
+  it("Refresh Page button triggers window.location.reload", () => {
+    const reloadSpy = vi.fn();
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...window.location, reload: reloadSpy },
+    });
+
+    render(
+      <ErrorBoundary>
+        <Boom />
+      </ErrorBoundary>
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Refresh Page/i }));
+    expect(reloadSpy).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/Layout.test.tsx
+++ b/frontend/src/components/Layout.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { Layout } from "./Layout";
+import { ToastProvider } from "../contexts/ToastContext";
+
+function renderLayout() {
+  return render(
+    <ToastProvider>
+      <MemoryRouter initialEntries={["/"]}>
+        <Routes>
+          <Route element={<Layout />}>
+            <Route path="/" element={<div data-testid="page">Home page</div>} />
+          </Route>
+        </Routes>
+      </MemoryRouter>
+    </ToastProvider>
+  );
+}
+
+describe("Layout", () => {
+  it("renders the navbar", () => {
+    renderLayout();
+    expect(screen.getByText("Rae Budget")).toBeInTheDocument();
+  });
+
+  it("renders the routed child via Outlet", () => {
+    renderLayout();
+    expect(screen.getByTestId("page")).toHaveTextContent("Home page");
+  });
+});

--- a/frontend/src/components/Navbar.test.tsx
+++ b/frontend/src/components/Navbar.test.tsx
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { Navbar } from "./Navbar";
+
+function renderNavbarAt(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Navbar />
+    </MemoryRouter>
+  );
+}
+
+describe("Navbar", () => {
+  it("renders the brand and all nav links", () => {
+    renderNavbarAt("/");
+    expect(screen.getByText("Rae Budget")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Dashboard" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Bill Templates" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Settings" })).toBeInTheDocument();
+  });
+
+  it("marks the Dashboard link active on /", () => {
+    renderNavbarAt("/");
+    expect(screen.getByRole("link", { name: "Dashboard" })).toHaveClass("active");
+    expect(screen.getByRole("link", { name: "Bill Templates" })).not.toHaveClass(
+      "active"
+    );
+  });
+
+  it("marks Bill Templates active on /bill-templates", () => {
+    renderNavbarAt("/bill-templates");
+    expect(screen.getByRole("link", { name: "Bill Templates" })).toHaveClass("active");
+    expect(screen.getByRole("link", { name: "Dashboard" })).not.toHaveClass("active");
+  });
+
+  it("marks Settings active on /settings", () => {
+    renderNavbarAt("/settings");
+    expect(screen.getByRole("link", { name: "Settings" })).toHaveClass("active");
+  });
+});

--- a/frontend/src/components/PayPeriodForm.test.tsx
+++ b/frontend/src/components/PayPeriodForm.test.tsx
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode } from "react";
+import { PayPeriodForm } from "./PayPeriodForm";
+import { ToastProvider } from "../contexts/ToastContext";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+function jsonResponse(status: number, body: unknown) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  };
+}
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <ToastProvider>{children}</ToastProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+describe("PayPeriodForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default mock for the suggestion + bill-templates queries that fire on mount
+    mockFetch.mockResolvedValue(
+      jsonResponse(200, { start_date: "2026-04-06", end_date: "2026-04-19" })
+    );
+  });
+
+  it("shows just the trigger button by default", () => {
+    render(<PayPeriodForm />, { wrapper: createWrapper() });
+    expect(
+      screen.getByRole("button", { name: /\+ New Pay Period/i })
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Create New Pay Period/)).not.toBeInTheDocument();
+  });
+
+  it("clicking the trigger reveals the form", () => {
+    render(<PayPeriodForm />, { wrapper: createWrapper() });
+    fireEvent.click(screen.getByRole("button", { name: /\+ New Pay Period/i }));
+    expect(screen.getByText("Create New Pay Period")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^Create$/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Cancel/i })).toBeInTheDocument();
+  });
+
+  it("auto-fills suggested dates after the suggestion query resolves", async () => {
+    render(<PayPeriodForm />, { wrapper: createWrapper() });
+    fireEvent.click(screen.getByRole("button", { name: /\+ New Pay Period/i }));
+    // Two date inputs — wait for the first one to populate
+    await waitFor(() => {
+      const dateInputs = screen
+        .getAllByDisplayValue(/2026-04/)
+        .filter((el) => (el as HTMLInputElement).type === "date");
+      expect(dateInputs.length).toBeGreaterThan(0);
+    });
+  });
+
+  it("Cancel returns to the trigger-only state", () => {
+    render(<PayPeriodForm />, { wrapper: createWrapper() });
+    fireEvent.click(screen.getByRole("button", { name: /\+ New Pay Period/i }));
+    fireEvent.click(screen.getByRole("button", { name: /Cancel/i }));
+    expect(screen.queryByText(/Create New Pay Period/)).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /\+ New Pay Period/i })
+    ).toBeInTheDocument();
+  });
+
+  it("submits POST with populate_bills query param when the toggle is on", async () => {
+    const { container } = render(<PayPeriodForm />, { wrapper: createWrapper() });
+    fireEvent.click(screen.getByRole("button", { name: /\+ New Pay Period/i }));
+
+    // Labels in this form aren't htmlFor-linked — query date inputs directly
+    const dateInputs = container.querySelectorAll(
+      'input[type="date"]'
+    ) as NodeListOf<HTMLInputElement>;
+    fireEvent.change(dateInputs[0], { target: { value: "2026-05-01" } });
+    fireEvent.change(dateInputs[1], { target: { value: "2026-05-14" } });
+    fireEvent.change(screen.getByPlaceholderText("0.00"), {
+      target: { value: "2500" },
+    });
+
+    mockFetch.mockResolvedValueOnce(jsonResponse(201, { id: 1 }));
+    mockFetch.mockResolvedValue(jsonResponse(200, []));
+
+    fireEvent.click(screen.getByRole("button", { name: /^Create$/i }));
+
+    await waitFor(() => {
+      const createCall = mockFetch.mock.calls.find(
+        (c) => c[0]?.includes("/pay-periods") && c[1]?.method === "POST"
+      );
+      expect(createCall).toBeTruthy();
+      // populateBills defaults to true
+      expect(createCall?.[0]).toContain("populate_bills=true");
+    });
+  });
+
+  it("calls onSuccess after a successful create", async () => {
+    const onSuccess = vi.fn();
+    const { container } = render(<PayPeriodForm onSuccess={onSuccess} />, {
+      wrapper: createWrapper(),
+    });
+    fireEvent.click(screen.getByRole("button", { name: /\+ New Pay Period/i }));
+
+    const dateInputs = container.querySelectorAll(
+      'input[type="date"]'
+    ) as NodeListOf<HTMLInputElement>;
+    fireEvent.change(dateInputs[0], { target: { value: "2026-05-01" } });
+    fireEvent.change(dateInputs[1], { target: { value: "2026-05-14" } });
+    fireEvent.change(screen.getByPlaceholderText("0.00"), {
+      target: { value: "2500" },
+    });
+
+    mockFetch.mockResolvedValueOnce(jsonResponse(201, { id: 99 }));
+
+    fireEvent.click(screen.getByRole("button", { name: /^Create$/i }));
+
+    await waitFor(() => expect(onSuccess).toHaveBeenCalled());
+  });
+});

--- a/frontend/src/components/PayPeriodSelector.test.tsx
+++ b/frontend/src/components/PayPeriodSelector.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { PayPeriodSelector } from "./PayPeriodSelector";
+import type { PayPeriod } from "../types";
+
+const mockPeriods: PayPeriod[] = [
+  {
+    id: 1,
+    start_date: "2026-04-06",
+    end_date: "2026-04-19",
+    expected_income: "2500.00",
+    actual_income: null,
+    additional_income: null,
+    additional_income_description: null,
+    notes: null,
+    created_at: "2026-04-01T00:00:00Z",
+    updated_at: "2026-04-01T00:00:00Z",
+  },
+  {
+    id: 2,
+    start_date: "2026-04-20",
+    end_date: "2026-05-05",
+    expected_income: "2500.00",
+    actual_income: null,
+    additional_income: null,
+    additional_income_description: null,
+    notes: null,
+    created_at: "2026-04-01T00:00:00Z",
+    updated_at: "2026-04-01T00:00:00Z",
+  },
+];
+
+describe("PayPeriodSelector", () => {
+  it("shows the empty-state message when there are no pay periods", () => {
+    render(<PayPeriodSelector payPeriods={[]} selectedId={undefined} onSelect={() => {}} />);
+    expect(screen.getByText(/No pay periods yet/)).toBeInTheDocument();
+  });
+
+  it("renders one option per pay period", () => {
+    render(
+      <PayPeriodSelector payPeriods={mockPeriods} selectedId={1} onSelect={() => {}} />
+    );
+    const options = screen.getAllByRole("option");
+    expect(options).toHaveLength(2);
+  });
+
+  it("calls onSelect with the parsed numeric id when changed", () => {
+    const onSelect = vi.fn();
+    render(
+      <PayPeriodSelector payPeriods={mockPeriods} selectedId={1} onSelect={onSelect} />
+    );
+    fireEvent.change(screen.getByRole("combobox"), { target: { value: "2" } });
+    expect(onSelect).toHaveBeenCalledWith(2);
+  });
+
+  it("reflects selectedId on the underlying select element", () => {
+    render(
+      <PayPeriodSelector payPeriods={mockPeriods} selectedId={2} onSelect={() => {}} />
+    );
+    expect((screen.getByRole("combobox") as HTMLSelectElement).value).toBe("2");
+  });
+});

--- a/frontend/src/components/SpendingTable.test.tsx
+++ b/frontend/src/components/SpendingTable.test.tsx
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode } from "react";
+import { SpendingTable } from "./SpendingTable";
+import { ToastProvider } from "../contexts/ToastContext";
+import type { SpendingEntry, Category } from "../types";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+const mockCategories: Category[] = [
+  {
+    id: 5,
+    name: "Food",
+    description: null,
+    color: "#f59e0b",
+    created_at: "2026-04-01T00:00:00Z",
+    updated_at: "2026-04-01T00:00:00Z",
+  },
+];
+
+const baseEntry: SpendingEntry = {
+  id: 1,
+  pay_period_id: 5,
+  category_id: 5,
+  description: "Lunch",
+  amount: "12.00",
+  spent_date: "2026-04-08",
+  notes: null,
+  created_at: "2026-04-08T00:00:00Z",
+  updated_at: "2026-04-08T00:00:00Z",
+};
+
+function jsonResponse(status: number, body: unknown) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  };
+}
+
+function noContentResponse() {
+  return { ok: true, status: 204 };
+}
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <ToastProvider>{children}</ToastProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+function renderTable(entries: SpendingEntry[]) {
+  // Component fetches categories on mount via useCategories
+  mockFetch.mockResolvedValueOnce(jsonResponse(200, mockCategories));
+  return render(<SpendingTable entries={entries} payPeriodId={5} />, {
+    wrapper: createWrapper(),
+  });
+}
+
+describe("SpendingTable", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows the empty-state message when there are no entries", () => {
+    renderTable([]);
+    expect(
+      screen.getByText(/No spending entries for this pay period/)
+    ).toBeInTheDocument();
+  });
+
+  it("renders entries with category badge", async () => {
+    renderTable([baseEntry]);
+    expect(screen.getByText("Lunch")).toBeInTheDocument();
+    // Category name shows up after the categories query resolves
+    expect(await screen.findByText("Food")).toBeInTheDocument();
+  });
+
+  it("sorts entries by date descending (newest first)", () => {
+    const older = { ...baseEntry, id: 1, spent_date: "2026-04-01", description: "Older" };
+    const newer = { ...baseEntry, id: 2, spent_date: "2026-04-15", description: "Newer" };
+    renderTable([older, newer]);
+
+    const rows = screen.getAllByRole("row");
+    // First data row (rows[0] is header) should be the newer entry
+    expect(within(rows[1]).getByText("Newer")).toBeInTheDocument();
+    expect(within(rows[2]).getByText("Older")).toBeInTheDocument();
+  });
+
+  it("running total accumulates top-to-bottom (sorted order)", () => {
+    const a = { ...baseEntry, id: 1, spent_date: "2026-04-01", amount: "10.00" };
+    const b = { ...baseEntry, id: 2, spent_date: "2026-04-15", amount: "25.00" };
+    renderTable([a, b]);
+
+    // Newer (25) is row 1 → running total $25; Older (10) is row 2 → running total $35
+    // Running total cell uses .font-mono to differentiate from amount.
+    const rows = screen.getAllByRole("row");
+    const row1RunningTotal = rows[1].querySelector(".font-mono");
+    const row2RunningTotal = rows[2].querySelector(".font-mono");
+    expect(row1RunningTotal).toHaveTextContent("$25.00");
+    expect(row2RunningTotal).toHaveTextContent("$35.00");
+  });
+
+  it("shows footer total summing all entries", () => {
+    const a = { ...baseEntry, id: 1, amount: "10.00" };
+    const b = { ...baseEntry, id: 2, amount: "25.00" };
+    renderTable([a, b]);
+    // Footer Total = 35.00
+    expect(screen.getAllByText("$35.00").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("Edit reveals inputs and Cancel exits", () => {
+    renderTable([baseEntry]);
+    fireEvent.click(screen.getByRole("button", { name: /Edit/i }));
+    expect(screen.getByDisplayValue("Lunch")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Cancel/i }));
+    expect(screen.queryByDisplayValue("Lunch")).not.toBeInTheDocument();
+  });
+
+  it("Save in edit mode PUTs the new values", async () => {
+    renderTable([baseEntry]);
+
+    fireEvent.click(screen.getByRole("button", { name: /Edit/i }));
+    fireEvent.change(screen.getByDisplayValue("Lunch"), {
+      target: { value: "Brunch" },
+    });
+
+    mockFetch.mockResolvedValueOnce(jsonResponse(200, { ...baseEntry, description: "Brunch" }));
+    mockFetch.mockResolvedValue(jsonResponse(200, []));
+
+    const editingRow = screen.getByDisplayValue("Brunch").closest("tr")!;
+    fireEvent.click(within(editingRow).getByRole("button", { name: /Save/i }));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/spending/1",
+        expect.objectContaining({
+          method: "PUT",
+          body: expect.stringContaining('"description":"Brunch"'),
+        })
+      );
+    });
+  });
+
+  it("Delete confirms then DELETEs", async () => {
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+    renderTable([baseEntry]);
+
+    mockFetch.mockResolvedValueOnce(noContentResponse());
+    mockFetch.mockResolvedValue(jsonResponse(200, []));
+
+    fireEvent.click(screen.getByRole("button", { name: /Delete/i }));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/spending/1",
+        expect.objectContaining({ method: "DELETE" })
+      );
+    });
+  });
+
+  it("Delete does nothing when the user cancels the confirm", () => {
+    vi.spyOn(window, "confirm").mockReturnValue(false);
+    renderTable([baseEntry]);
+    const before = mockFetch.mock.calls.length;
+    fireEvent.click(screen.getByRole("button", { name: /Delete/i }));
+    expect(mockFetch.mock.calls.length).toBe(before);
+  });
+});

--- a/frontend/src/pages/BillTemplates.test.tsx
+++ b/frontend/src/pages/BillTemplates.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode } from "react";
+import { BillTemplates } from "./BillTemplates";
+import { ToastProvider } from "../contexts/ToastContext";
+import type { BillTemplate } from "../types";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+const mockTemplate: BillTemplate = {
+  id: 1,
+  name: "Rent",
+  default_amount: "1500.00",
+  due_day_of_month: 1,
+  is_recurring: true,
+  category_id: null,
+  notes: null,
+  created_at: "2026-04-01T00:00:00Z",
+  updated_at: "2026-04-01T00:00:00Z",
+};
+
+function jsonResponse(status: number, body: unknown) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  };
+}
+
+function noContentResponse() {
+  return { ok: true, status: 204 };
+}
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <ToastProvider>{children}</ToastProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+describe("BillTemplates page", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows the empty-state message when there are no templates", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(200, []));
+    render(<BillTemplates />, { wrapper: createWrapper() });
+    expect(await screen.findByText(/No bill templates yet/)).toBeInTheDocument();
+  });
+
+  it("renders template rows with formatted amount and ordinal due day", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(200, [mockTemplate]));
+    render(<BillTemplates />, { wrapper: createWrapper() });
+    expect(await screen.findByText("Rent")).toBeInTheDocument();
+    expect(screen.getByText("$1,500.00")).toBeInTheDocument();
+    expect(screen.getByText("1st")).toBeInTheDocument();
+  });
+
+  it("submits a POST when the add form is filled and submitted", async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse(200, []));
+    render(<BillTemplates />, { wrapper: createWrapper() });
+    await screen.findByText(/No bill templates yet/);
+
+    fireEvent.change(screen.getByPlaceholderText("e.g., Rent, Electric"), {
+      target: { value: "Internet" },
+    });
+    fireEvent.change(screen.getByPlaceholderText("0.00"), {
+      target: { value: "75" },
+    });
+
+    mockFetch.mockResolvedValueOnce(jsonResponse(201, { ...mockTemplate, name: "Internet" }));
+    mockFetch.mockResolvedValue(jsonResponse(200, []));
+
+    fireEvent.click(screen.getByRole("button", { name: /Add Template/i }));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/bill-templates",
+        expect.objectContaining({
+          method: "POST",
+          body: expect.stringContaining('"name":"Internet"'),
+        })
+      );
+    });
+  });
+
+  it("Delete confirms then DELETEs", async () => {
+    vi.spyOn(window, "confirm").mockReturnValue(true);
+    mockFetch.mockResolvedValueOnce(jsonResponse(200, [mockTemplate]));
+    render(<BillTemplates />, { wrapper: createWrapper() });
+    await screen.findByText("Rent");
+
+    mockFetch.mockResolvedValueOnce(noContentResponse());
+    mockFetch.mockResolvedValue(jsonResponse(200, []));
+
+    fireEvent.click(screen.getByRole("button", { name: /Delete/i }));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/bill-templates/1",
+        expect.objectContaining({ method: "DELETE" })
+      );
+    });
+  });
+});

--- a/frontend/src/pages/Dashboard.test.tsx
+++ b/frontend/src/pages/Dashboard.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode } from "react";
+import { Dashboard } from "./Dashboard";
+import { ToastProvider } from "../contexts/ToastContext";
+import type { PayPeriod, PayPeriodDetail } from "../types";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+const mockPayPeriod: PayPeriod = {
+  id: 1,
+  start_date: "2026-04-06",
+  end_date: "2026-04-19",
+  expected_income: "2500.00",
+  actual_income: null,
+  additional_income: null,
+  additional_income_description: null,
+  notes: null,
+  created_at: "2026-04-01T00:00:00Z",
+  updated_at: "2026-04-01T00:00:00Z",
+};
+
+const mockPayPeriodDetail: PayPeriodDetail = {
+  ...mockPayPeriod,
+  summary: {
+    bill_total: "0.00",
+    spending_total: "0.00",
+    running_total: "0.00",
+    remaining: "2500.00",
+  },
+};
+
+function jsonResponse(status: number, body: unknown) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  };
+}
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <ToastProvider>{children}</ToastProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+describe("Dashboard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows a spinner while pay periods load", () => {
+    mockFetch.mockReturnValue(new Promise(() => {})); // never resolves
+    const { container } = render(<Dashboard />, { wrapper: createWrapper() });
+    expect(container.querySelector(".loading-spinner")).toBeInTheDocument();
+  });
+
+  it("shows the welcome message when no pay periods exist", async () => {
+    // /pay-periods → empty
+    mockFetch.mockResolvedValue(jsonResponse(200, []));
+    render(<Dashboard />, { wrapper: createWrapper() });
+    expect(
+      await screen.findByText(/Welcome! Create your first pay period/)
+    ).toBeInTheDocument();
+  });
+
+  it("auto-selects the first pay period and renders the summary", async () => {
+    mockFetch.mockImplementation((url: string) => {
+      if (url === "/api/pay-periods") return Promise.resolve(jsonResponse(200, [mockPayPeriod]));
+      if (url === `/api/pay-periods/1`) return Promise.resolve(jsonResponse(200, mockPayPeriodDetail));
+      // bills, spending, suggest, bill-templates, categories — all empty
+      return Promise.resolve(jsonResponse(200, []));
+    });
+
+    render(<Dashboard />, { wrapper: createWrapper() });
+    // Summary card title
+    await waitFor(() => {
+      expect(screen.getByText(/Pay Period:/)).toBeInTheDocument();
+    });
+    // Bills section header
+    expect(screen.getByText("Bills")).toBeInTheDocument();
+    // Additional Spending section header
+    expect(screen.getByText("Additional Spending")).toBeInTheDocument();
+  });
+
+  it("renders the New Pay Period button regardless of state", async () => {
+    mockFetch.mockResolvedValue(jsonResponse(200, []));
+    render(<Dashboard />, { wrapper: createWrapper() });
+    expect(
+      await screen.findByRole("button", { name: /\+ New Pay Period/i })
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/Settings.test.tsx
+++ b/frontend/src/pages/Settings.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode } from "react";
+import { Settings } from "./Settings";
+import { ToastProvider } from "../contexts/ToastContext";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+function jsonResponse(status: number, body: unknown) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  };
+}
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <ToastProvider>{children}</ToastProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+describe("Settings page", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Categories fetch from CategoryManagement
+    mockFetch.mockResolvedValue(jsonResponse(200, []));
+  });
+
+  it("renders the three top-level sections", async () => {
+    render(<Settings />, { wrapper: createWrapper() });
+    expect(screen.getByRole("heading", { name: "Settings" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Categories" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "Data Management" })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "About Rae Budget" })).toBeInTheDocument();
+  });
+
+  it("renders the categories section with the management UI", async () => {
+    render(<Settings />, { wrapper: createWrapper() });
+    expect(
+      await screen.findByText(/Categories help organize your bills/)
+    ).toBeInTheDocument();
+  });
+
+  it("renders the about section with version info", () => {
+    render(<Settings />, { wrapper: createWrapper() });
+    expect(screen.getByText(/Version:/)).toBeInTheDocument();
+    expect(screen.getByText(/Stack:/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/utils/date.test.ts
+++ b/frontend/src/utils/date.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import { parseLocalDate, formatDate, formatDateRange } from "./date";
+
+describe("parseLocalDate", () => {
+  it("parses a YYYY-MM-DD string as a local date", () => {
+    const date = parseLocalDate("2026-04-06");
+    expect(date).not.toBeNull();
+    expect(date!.getFullYear()).toBe(2026);
+    expect(date!.getMonth()).toBe(3); // April (0-indexed)
+    expect(date!.getDate()).toBe(6);
+  });
+
+  it("returns null for null input", () => {
+    expect(parseLocalDate(null)).toBeNull();
+  });
+
+  it("returns null for undefined input", () => {
+    expect(parseLocalDate(undefined)).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(parseLocalDate("")).toBeNull();
+  });
+
+  it("returns null for malformed (wrong number of parts)", () => {
+    expect(parseLocalDate("2026/04/06")).toBeNull();
+    expect(parseLocalDate("2026-04")).toBeNull();
+  });
+
+  it("returns null when parts are not numeric", () => {
+    expect(parseLocalDate("abcd-ef-gh")).toBeNull();
+  });
+});
+
+describe("formatDate", () => {
+  it("formats a valid date with default options", () => {
+    const result = formatDate("2026-04-06");
+    expect(result).toContain("Apr");
+    expect(result).toContain("6");
+    expect(result).toContain("2026");
+  });
+
+  it("respects custom options", () => {
+    const result = formatDate("2026-04-06", { month: "short", day: "numeric" });
+    expect(result).toContain("Apr");
+    expect(result).toContain("6");
+    // Year should NOT be present
+    expect(result).not.toContain("2026");
+  });
+
+  it("returns '-' for null", () => {
+    expect(formatDate(null)).toBe("-");
+  });
+
+  it("returns '-' for invalid string", () => {
+    expect(formatDate("not-a-date")).toBe("-");
+  });
+});
+
+describe("formatDateRange", () => {
+  it("formats a range as 'start - end'", () => {
+    const result = formatDateRange("2026-04-06", "2026-04-19");
+    expect(result).toContain("Apr");
+    expect(result).toContain("6");
+    expect(result).toContain("19");
+    expect(result).toContain(" - ");
+  });
+
+  it("includes year only on the end date", () => {
+    const result = formatDateRange("2026-04-06", "2026-04-19");
+    // Year appears once (on the end)
+    const yearMatches = result.match(/2026/g) ?? [];
+    expect(yearMatches.length).toBe(1);
+  });
+});

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -18,5 +18,17 @@ export default defineConfig({
     environment: "jsdom",
     setupFiles: ["./src/test/setup.ts"],
     include: ["src/**/*.{test,spec}.{ts,tsx}"],
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "lcov", "html"],
+      include: ["src/**/*.{ts,tsx}"],
+      exclude: [
+        "src/**/*.{test,spec}.{ts,tsx}",
+        "src/test/**",
+        "src/main.tsx",
+        "src/vite-env.d.ts",
+        "src/types/**",
+      ],
+    },
   },
 });


### PR DESCRIPTION
## Summary

Major test-coverage push plus Codecov wiring. Coverage jumped from baseline of ~61% backend / ~19% frontend to **94% backend / 87% frontend**, with **278 passing tests** (153 backend + 125 frontend).

### Codecov
- Added a Frontend Tests job to \`.github/workflows/ci.yml\`
- Both backend and frontend test jobs now upload to Codecov, flagged as \`backend\` / \`frontend\`
- Backend writes \`coverage.xml\`; frontend writes \`coverage/lcov.info\` via vitest's v8 coverage provider configured in \`vite.config.ts\`
- Codecov badge added to README
- New \`@vitest/coverage-v8\` dev dep
- Coverage output directories added to \`.gitignore\`

### Backend tests
- New: \`test_categories.py\`, \`test_bill_templates.py\`, \`test_health.py\`
- Extended: \`test_pay_periods.py\`, \`test_bills.py\`, \`test_spending.py\` with route tests
- Per-route deltas: bill_templates 21→89, bills 19→88, categories 19→87, pay_periods 17→88, spending 19→88, health 38→100

### Bug fix (caught while writing pay-period validation tests)
- \`fix: return 400 instead of 500 for Pydantic validation errors\` — Pydantic 2 puts the raw \`ValueError\` instance in \`ctx.error\` of \`e.errors()\`, which Flask's \`jsonify\` can't serialize. Schema-level model_validator failures (e.g., end_date < start_date) crashed with 500 instead of returning a clean 400. Fixed across all 6 routes by switching to \`json.loads(e.json())\`.

### Frontend tests
14 new test files covering components, pages, and utils:
- Components: AddBillForm, AddSpendingForm, AdditionalIncomeCard, BillsTable, CategoryManagement, ErrorBoundary, Layout, Navbar, PayPeriodForm, PayPeriodSelector, SpendingTable
- Pages: BillTemplates, Dashboard, Settings
- Utils: date

Notable coverage of: ApiError/409 conflict paths, inline-edit flows, confirm-delete dialogs, route active-state, error boundary recovery, date parsing edge cases.

### Tooling fix
- Added \`postinstall: npm rebuild rollup\` to \`frontend/package.json\` to work around npm's optional-dependency bug for rollup's native binaries (\`@rollup/rollup-darwin-*\`). Keeps node_modules consistent across architectures after every install.

## Test plan

- [ ] Backend: \`docker compose exec api uv run pytest tests/ --cov=app --cov-report=term\` — 153 tests passing, ~94% coverage
- [ ] Frontend: \`(cd frontend && npm run test:coverage)\` — 125 tests passing, ~87% coverage
- [ ] CI: confirm \`Frontend Tests\` job appears and passes
- [ ] CI: confirm Codecov upload steps run for both flags (\`backend\`, \`frontend\`)
- [ ] After merge: confirm Codecov badge in README resolves to a real percentage
- [ ] Manual: try creating a pay period with end_date < start_date — should get a clean 400, not 500

## Notes for merging

- The bug fix is a \`fix:\` commit → release-please will bump the patch version
- Test additions don't affect the bumped version
- Make sure \`CODECOV_TOKEN\` is set as a repo secret before merging (Settings → Secrets and variables → Actions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)