### PR TITLE
ci: run on push to main so Codecov gets a baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   pull_request:
+  push:
+    branches: [main]
 
 jobs:
   backend-lint:


### PR DESCRIPTION
## Summary

CI was only triggered by \`pull_request\`, so Codecov never received coverage data for \`main\` itself. Per-PR Codecov diffs ("this drops coverage by X%") had nothing to compare against.

This adds \`push: branches: [main]\` to the workflow trigger. After this merges, the workflow will fire on the merge commit and upload main's first coverage baseline. Every subsequent merge updates that baseline.

## Test plan

- [ ] After merge, confirm the CI workflow runs on the merge commit to main
- [ ] Confirm both backend and frontend Codecov uploads succeed for main
- [ ] On the next PR, confirm Codecov posts a coverage diff comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)