### PR TITLE
feat: add Insights page scaffold with filter toolbar and aggregations hook

### DIFF
--- a/backend/app/routes/bills.py
+++ b/backend/app/routes/bills.py
@@ -14,6 +14,21 @@ from app.schemas import (
 bills_bp = Blueprint("bills", __name__)
 
 
+@bills_bp.route("/bills", methods=["GET"])
+def list_all_bills():
+    """List all bills across every pay period (used by the Insights dashboard)."""
+    session = db.get_session()
+    try:
+        bills = session.query(PayPeriodBill).all()
+        result = [
+            PayPeriodBillResponse.model_validate(bill).model_dump(mode="json")
+            for bill in bills
+        ]
+        return jsonify(result)
+    finally:
+        session.close()
+
+
 @bills_bp.route("/pay-periods/<int:pay_period_id>/bills", methods=["GET"])
 def list_bills(pay_period_id: int):
     """List all bills for a pay period."""

--- a/backend/app/routes/spending.py
+++ b/backend/app/routes/spending.py
@@ -14,6 +14,21 @@ from app.schemas import (
 spending_bp = Blueprint("spending", __name__)
 
 
+@spending_bp.route("/spending", methods=["GET"])
+def list_all_spending():
+    """List all spending entries across every pay period (used by the Insights dashboard)."""
+    session = db.get_session()
+    try:
+        entries = session.query(SpendingEntry).all()
+        result = [
+            SpendingEntryResponse.model_validate(entry).model_dump(mode="json")
+            for entry in entries
+        ]
+        return jsonify(result)
+    finally:
+        session.close()
+
+
 @spending_bp.route("/pay-periods/<int:pay_period_id>/spending", methods=["GET"])
 def list_spending(pay_period_id: int):
     """List all spending entries for a pay period."""

--- a/backend/tests/test_bills.py
+++ b/backend/tests/test_bills.py
@@ -115,6 +115,44 @@ class TestListBills:
         assert response.status_code == 404
 
 
+class TestListAllBills:
+    """GET /api/bills — unfiltered list across pay periods."""
+
+    def test_empty(self, client, session):
+        response = client.get("/api/bills")
+        assert response.status_code == 200
+        assert response.get_json() == []
+
+    def test_returns_bills_from_multiple_pay_periods(
+        self, client, session, sample_pay_period, sample_bill
+    ):
+        # Add a second pay period with its own bill
+        from app.models import PayPeriod
+
+        other_pp = PayPeriod(
+            start_date=date(2026, 4, 20),
+            end_date=date(2026, 5, 5),
+            expected_income=Decimal("2500.00"),
+        )
+        session.add(other_pp)
+        session.commit()
+        session.add(
+            PayPeriodBill(
+                pay_period_id=other_pp.id,
+                name="Internet",
+                amount=Decimal("80.00"),
+                due_date=date(2026, 4, 22),
+            )
+        )
+        session.commit()
+
+        response = client.get("/api/bills")
+        body = response.get_json()
+        assert len(body) == 2
+        names = sorted(b["name"] for b in body)
+        assert names == ["Internet", "Rent"]
+
+
 class TestCreateBill:
     """POST /api/pay-periods/:id/bills"""
 

--- a/backend/tests/test_spending.py
+++ b/backend/tests/test_spending.py
@@ -88,6 +88,43 @@ class TestListSpending:
         assert response.status_code == 404
 
 
+class TestListAllSpending:
+    """GET /api/spending — unfiltered list across pay periods."""
+
+    def test_empty(self, client, session):
+        response = client.get("/api/spending")
+        assert response.status_code == 200
+        assert response.get_json() == []
+
+    def test_returns_entries_from_multiple_pay_periods(
+        self, client, session, sample_pay_period, sample_spending
+    ):
+        from app.models import PayPeriod, SpendingEntry
+
+        other_pp = PayPeriod(
+            start_date=date(2026, 4, 20),
+            end_date=date(2026, 5, 5),
+            expected_income=Decimal("2500.00"),
+        )
+        session.add(other_pp)
+        session.commit()
+        session.add(
+            SpendingEntry(
+                pay_period_id=other_pp.id,
+                description="Coffee",
+                amount=Decimal("5.00"),
+                spent_date=date(2026, 4, 22),
+            )
+        )
+        session.commit()
+
+        response = client.get("/api/spending")
+        body = response.get_json()
+        assert len(body) == 2
+        descriptions = sorted(e["description"] for e in body)
+        assert descriptions == ["Coffee", "Groceries at Publix"]
+
+
 class TestCreateSpending:
     """POST /api/pay-periods/:id/spending"""
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { Layout } from './components/Layout';
 import { Dashboard } from './pages/Dashboard';
 import { BillTemplates } from './pages/BillTemplates';
+import { Insights } from './pages/Insights';
 import { Settings } from './pages/Settings';
 
 function App() {
@@ -10,6 +11,7 @@ function App() {
       <Routes>
         <Route path="/" element={<Layout />}>
           <Route index element={<Dashboard />} />
+          <Route path="insights" element={<Insights />} />
           <Route path="bill-templates" element={<BillTemplates />} />
           <Route path="settings" element={<Settings />} />
         </Route>

--- a/frontend/src/components/InsightsToolbar.test.tsx
+++ b/frontend/src/components/InsightsToolbar.test.tsx
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { InsightsToolbar } from './InsightsToolbar';
+import type { Category } from '../types';
+import type { InsightsFilter } from '../hooks/useInsights';
+
+const categories: Category[] = [
+  {
+    id: 10,
+    name: 'Food',
+    description: null,
+    color: '#f59e0b',
+    monthly_target: '500.00',
+    created_at: '2026-04-01T00:00:00Z',
+    updated_at: '2026-04-01T00:00:00Z',
+  },
+  {
+    id: 20,
+    name: 'Travel',
+    description: null,
+    color: '#3b82f6',
+    monthly_target: null,
+    created_at: '2026-04-01T00:00:00Z',
+    updated_at: '2026-04-01T00:00:00Z',
+  },
+];
+
+const defaultFilter: InsightsFilter = {
+  rangeMode: 'last-n',
+  n: 6,
+  include: 'both',
+  categoryIds: [],
+};
+
+describe('InsightsToolbar', () => {
+  let onChange: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    onChange = vi.fn();
+  });
+
+  it('selects the matching range preset on render', () => {
+    render(
+      <InsightsToolbar
+        filter={defaultFilter}
+        onChange={onChange}
+        categories={categories}
+      />,
+    );
+    const select = screen.getByLabelText('Range') as HTMLSelectElement;
+    expect(select.value).toBe('last-n:6');
+  });
+
+  it('emits a new filter when changing the range preset', () => {
+    render(
+      <InsightsToolbar
+        filter={defaultFilter}
+        onChange={onChange}
+        categories={categories}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText('Range'), {
+      target: { value: 'last-n:3' },
+    });
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ rangeMode: 'last-n', n: 3 }),
+    );
+  });
+
+  it('shows custom date pickers when Custom range is selected', () => {
+    render(
+      <InsightsToolbar
+        filter={{ ...defaultFilter, rangeMode: 'custom' }}
+        onChange={onChange}
+        categories={categories}
+      />,
+    );
+    expect(screen.getByLabelText('From date')).toBeInTheDocument();
+    expect(screen.getByLabelText('To date')).toBeInTheDocument();
+  });
+
+  it('does not show date pickers for non-custom ranges', () => {
+    render(
+      <InsightsToolbar
+        filter={defaultFilter}
+        onChange={onChange}
+        categories={categories}
+      />,
+    );
+    expect(screen.queryByLabelText('From date')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('To date')).not.toBeInTheDocument();
+  });
+
+  it('toggling a category checkbox emits the new selection', () => {
+    render(
+      <InsightsToolbar
+        filter={defaultFilter}
+        onChange={onChange}
+        categories={categories}
+      />,
+    );
+    const foodCheckbox = screen.getByLabelText(/Food/) as HTMLInputElement;
+    fireEvent.click(foodCheckbox);
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ categoryIds: [10] }),
+    );
+  });
+
+  it('shows selected category count in the dropdown trigger', () => {
+    render(
+      <InsightsToolbar
+        filter={{ ...defaultFilter, categoryIds: [10, 20] }}
+        onChange={onChange}
+        categories={categories}
+      />,
+    );
+    expect(screen.getByLabelText('Categories filter')).toHaveTextContent(
+      '2 categories',
+    );
+  });
+
+  it('emits min/max amount changes', () => {
+    render(
+      <InsightsToolbar
+        filter={defaultFilter}
+        onChange={onChange}
+        categories={categories}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText('Minimum amount'), {
+      target: { value: '20' },
+    });
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ minAmount: 20 }),
+    );
+    fireEvent.change(screen.getByLabelText('Maximum amount'), {
+      target: { value: '100' },
+    });
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ maxAmount: 100 }),
+    );
+  });
+
+  it('clears amount when input is emptied', () => {
+    render(
+      <InsightsToolbar
+        filter={{ ...defaultFilter, minAmount: 20 }}
+        onChange={onChange}
+        categories={categories}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText('Minimum amount'), {
+      target: { value: '' },
+    });
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ minAmount: undefined }),
+    );
+  });
+
+  it('include toggle switches between Bills, Spending, Both', () => {
+    render(
+      <InsightsToolbar
+        filter={defaultFilter}
+        onChange={onChange}
+        categories={categories}
+      />,
+    );
+    const group = screen.getByRole('radiogroup', { name: 'Include' });
+    fireEvent.click(within(group).getByRole('radio', { name: 'Bills' }));
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ include: 'bills' }),
+    );
+    fireEvent.click(within(group).getByRole('radio', { name: 'Spending' }));
+    expect(onChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({ include: 'spending' }),
+    );
+  });
+
+  it('shows "No categories yet" when none exist', () => {
+    render(
+      <InsightsToolbar
+        filter={defaultFilter}
+        onChange={onChange}
+        categories={[]}
+      />,
+    );
+    expect(screen.getByText(/No categories yet/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/InsightsToolbar.tsx
+++ b/frontend/src/components/InsightsToolbar.tsx
@@ -1,0 +1,247 @@
+import type { Category } from '../types';
+import type {
+  InsightsFilter,
+  InsightsInclude,
+  InsightsRangeMode,
+} from '../hooks/useInsights';
+
+interface Props {
+  filter: InsightsFilter;
+  onChange: (next: InsightsFilter) => void;
+  categories: Category[];
+}
+
+const RANGE_PRESETS: { label: string; mode: InsightsRangeMode; n?: number }[] = [
+  { label: 'Last 3 periods', mode: 'last-n', n: 3 },
+  { label: 'Last 6 periods', mode: 'last-n', n: 6 },
+  { label: 'Last 12 periods', mode: 'last-n', n: 12 },
+  { label: 'Year to date', mode: 'ytd' },
+  { label: 'Custom range', mode: 'custom' },
+];
+
+function rangeKey(filter: InsightsFilter): string {
+  if (filter.rangeMode === 'last-n') return `last-n:${filter.n ?? 6}`;
+  return filter.rangeMode;
+}
+
+export function InsightsToolbar({ filter, onChange, categories }: Props) {
+  const selectedRangeKey = rangeKey(filter);
+
+  const handleRangeChange = (key: string) => {
+    if (key === 'ytd') {
+      onChange({ ...filter, rangeMode: 'ytd', n: undefined });
+      return;
+    }
+    if (key === 'custom') {
+      onChange({ ...filter, rangeMode: 'custom', n: undefined });
+      return;
+    }
+    const n = Number(key.split(':')[1]);
+    onChange({ ...filter, rangeMode: 'last-n', n });
+  };
+
+  const toggleCategory = (id: number) => {
+    const current = filter.categoryIds ?? [];
+    const next = current.includes(id)
+      ? current.filter((c) => c !== id)
+      : [...current, id];
+    onChange({ ...filter, categoryIds: next });
+  };
+
+  const clearCategories = () => onChange({ ...filter, categoryIds: [] });
+
+  const handleAmountChange = (
+    field: 'minAmount' | 'maxAmount',
+    value: string,
+  ) => {
+    if (value === '') {
+      onChange({ ...filter, [field]: undefined });
+      return;
+    }
+    const num = Number(value);
+    if (Number.isFinite(num)) {
+      onChange({ ...filter, [field]: num });
+    }
+  };
+
+  const selectedCount = filter.categoryIds?.length ?? 0;
+  const categoryButtonLabel =
+    selectedCount === 0
+      ? 'All categories'
+      : selectedCount === 1
+        ? '1 category'
+        : `${selectedCount} categories`;
+
+  return (
+    <div className="card bg-base-100 shadow">
+      <div className="card-body p-4 gap-4">
+        <div className="flex flex-wrap gap-3 items-end">
+          {/* Range */}
+          <div className="flex flex-col">
+            <label className="label py-1">
+              <span className="label-text">Range</span>
+            </label>
+            <select
+              className="select select-bordered select-sm"
+              value={selectedRangeKey}
+              onChange={(e) => handleRangeChange(e.target.value)}
+              aria-label="Range"
+            >
+              {RANGE_PRESETS.map((p) => {
+                const key = p.mode === 'last-n' ? `last-n:${p.n}` : p.mode;
+                return (
+                  <option key={key} value={key}>
+                    {p.label}
+                  </option>
+                );
+              })}
+            </select>
+          </div>
+
+          {/* Custom range dates */}
+          {filter.rangeMode === 'custom' && (
+            <>
+              <div className="flex flex-col">
+                <label className="label py-1">
+                  <span className="label-text">From</span>
+                </label>
+                <input
+                  type="date"
+                  className="input input-bordered input-sm"
+                  value={filter.fromDate ?? ''}
+                  onChange={(e) =>
+                    onChange({ ...filter, fromDate: e.target.value || undefined })
+                  }
+                  aria-label="From date"
+                />
+              </div>
+              <div className="flex flex-col">
+                <label className="label py-1">
+                  <span className="label-text">To</span>
+                </label>
+                <input
+                  type="date"
+                  className="input input-bordered input-sm"
+                  value={filter.toDate ?? ''}
+                  onChange={(e) =>
+                    onChange({ ...filter, toDate: e.target.value || undefined })
+                  }
+                  aria-label="To date"
+                />
+              </div>
+            </>
+          )}
+
+          {/* Categories */}
+          <div className="flex flex-col">
+            <label className="label py-1">
+              <span className="label-text">Categories</span>
+            </label>
+            <details className="dropdown">
+              <summary
+                className="btn btn-sm btn-outline w-44 justify-between"
+                aria-label="Categories filter"
+              >
+                <span>{categoryButtonLabel}</span>
+                <span aria-hidden>▾</span>
+              </summary>
+              <div className="dropdown-content z-10 menu p-2 shadow bg-base-100 rounded-box w-56 max-h-64 overflow-y-auto">
+                {categories.length === 0 ? (
+                  <div className="text-sm text-base-content/60 px-2 py-1">
+                    No categories yet
+                  </div>
+                ) : (
+                  <>
+                    {categories.map((c) => {
+                      const checked = filter.categoryIds?.includes(c.id) ?? false;
+                      return (
+                        <label
+                          key={c.id}
+                          className="flex items-center gap-2 px-2 py-1 cursor-pointer hover:bg-base-200 rounded"
+                        >
+                          <input
+                            type="checkbox"
+                            className="checkbox checkbox-sm"
+                            checked={checked}
+                            onChange={() => toggleCategory(c.id)}
+                          />
+                          <span
+                            className="w-3 h-3 rounded inline-block"
+                            style={{ backgroundColor: c.color }}
+                          />
+                          <span className="text-sm">{c.name}</span>
+                        </label>
+                      );
+                    })}
+                    {selectedCount > 0 && (
+                      <button
+                        type="button"
+                        className="btn btn-xs btn-ghost mt-1"
+                        onClick={clearCategories}
+                      >
+                        Clear
+                      </button>
+                    )}
+                  </>
+                )}
+              </div>
+            </details>
+          </div>
+
+          {/* Min/Max amount */}
+          <div className="flex flex-col">
+            <label className="label py-1">
+              <span className="label-text">Min $</span>
+            </label>
+            <input
+              type="number"
+              step="0.01"
+              min="0"
+              className="input input-bordered input-sm w-24"
+              value={filter.minAmount ?? ''}
+              onChange={(e) => handleAmountChange('minAmount', e.target.value)}
+              placeholder="—"
+              aria-label="Minimum amount"
+            />
+          </div>
+          <div className="flex flex-col">
+            <label className="label py-1">
+              <span className="label-text">Max $</span>
+            </label>
+            <input
+              type="number"
+              step="0.01"
+              min="0"
+              className="input input-bordered input-sm w-24"
+              value={filter.maxAmount ?? ''}
+              onChange={(e) => handleAmountChange('maxAmount', e.target.value)}
+              placeholder="—"
+              aria-label="Maximum amount"
+            />
+          </div>
+
+          {/* Include toggle */}
+          <div className="flex flex-col">
+            <label className="label py-1">
+              <span className="label-text">Include</span>
+            </label>
+            <div role="radiogroup" className="join" aria-label="Include">
+              {(['both', 'spending', 'bills'] as InsightsInclude[]).map((v) => (
+                <button
+                  key={v}
+                  type="button"
+                  role="radio"
+                  aria-checked={filter.include === v}
+                  className={`join-item btn btn-sm ${filter.include === v ? 'btn-primary' : 'btn-outline'}`}
+                  onClick={() => onChange({ ...filter, include: v })}
+                >
+                  {v === 'both' ? 'Both' : v === 'spending' ? 'Spending' : 'Bills'}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -24,6 +24,14 @@ export function Navbar() {
           </li>
           <li>
             <Link
+              to="/insights"
+              className={isActive('/insights') ? 'active' : ''}
+            >
+              Insights
+            </Link>
+          </li>
+          <li>
+            <Link
               to="/bill-templates"
               className={isActive('/bill-templates') ? 'active' : ''}
             >

--- a/frontend/src/hooks/useBills.ts
+++ b/frontend/src/hooks/useBills.ts
@@ -11,6 +11,7 @@ export const billKeys = {
   all: ['bills'] as const,
   lists: () => [...billKeys.all, 'list'] as const,
   list: (payPeriodId: number) => [...billKeys.lists(), payPeriodId] as const,
+  allBills: () => [...billKeys.all, 'all'] as const,
 };
 
 export function useBills(payPeriodId: number | undefined) {
@@ -18,6 +19,13 @@ export function useBills(payPeriodId: number | undefined) {
     queryKey: billKeys.list(payPeriodId!),
     queryFn: () => api.get<PayPeriodBill[]>(`/pay-periods/${payPeriodId}/bills`),
     enabled: !!payPeriodId,
+  });
+}
+
+export function useAllBills() {
+  return useQuery({
+    queryKey: billKeys.allBills(),
+    queryFn: () => api.get<PayPeriodBill[]>('/bills'),
   });
 }
 

--- a/frontend/src/hooks/useInsights.test.tsx
+++ b/frontend/src/hooks/useInsights.test.tsx
@@ -1,0 +1,299 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactNode } from 'react';
+import { useInsights, type InsightsFilter } from './useInsights';
+import { api } from '../services/api';
+import type {
+  Category,
+  PayPeriod,
+  PayPeriodBill,
+  SpendingEntry,
+} from '../types';
+
+vi.mock('../services/api', () => ({
+  api: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+const mockCategories: Category[] = [
+  {
+    id: 10,
+    name: 'Food',
+    description: null,
+    color: '#f59e0b',
+    monthly_target: '500.00',
+    created_at: '2026-04-01T00:00:00Z',
+    updated_at: '2026-04-01T00:00:00Z',
+  },
+  {
+    id: 20,
+    name: 'Travel',
+    description: null,
+    color: '#3b82f6',
+    monthly_target: null,
+    created_at: '2026-04-01T00:00:00Z',
+    updated_at: '2026-04-01T00:00:00Z',
+  },
+];
+
+// Six pay periods, oldest to newest. start_date is what filterPeriods sorts on.
+const mockPayPeriods: PayPeriod[] = [
+  makePeriod(1, '2025-12-06', '2025-12-19'),
+  makePeriod(2, '2025-12-20', '2026-01-05'),
+  makePeriod(3, '2026-02-06', '2026-02-19'),
+  makePeriod(4, '2026-03-06', '2026-03-19'),
+  makePeriod(5, '2026-04-06', '2026-04-19'),
+  makePeriod(6, '2026-04-20', '2026-05-05'),
+];
+
+const mockSpending: SpendingEntry[] = [
+  // Period 5 (Apr 6–19): 100 Food + 50 Travel
+  makeEntry(101, 5, 10, '100.00', '2026-04-08'),
+  makeEntry(102, 5, 20, '50.00', '2026-04-10'),
+  // Period 6 (Apr 20–May 5): 200 Food + 30 uncategorized
+  makeEntry(103, 6, 10, '200.00', '2026-04-22'),
+  makeEntry(104, 6, null, '30.00', '2026-04-25'),
+  // Period 1 (Dec 2025): 75 Food (out of last-6 default range when others present)
+  makeEntry(105, 1, 10, '75.00', '2025-12-08'),
+];
+
+const mockBills: PayPeriodBill[] = [
+  makeBill(201, 5, '1500.00'),
+  makeBill(202, 6, '1500.00'),
+  makeBill(203, 1, '1400.00'),
+];
+
+function makePeriod(id: number, start: string, end: string): PayPeriod {
+  return {
+    id,
+    start_date: start,
+    end_date: end,
+    expected_income: '2500.00',
+    actual_income: null,
+    additional_income: null,
+    additional_income_description: null,
+    notes: null,
+    created_at: '2026-04-01T00:00:00Z',
+    updated_at: '2026-04-01T00:00:00Z',
+  };
+}
+
+function makeEntry(
+  id: number,
+  payPeriodId: number,
+  categoryId: number | null,
+  amount: string,
+  spentDate: string,
+): SpendingEntry {
+  return {
+    id,
+    pay_period_id: payPeriodId,
+    category_id: categoryId,
+    description: 'test',
+    amount,
+    spent_date: spentDate,
+    notes: null,
+    created_at: '2026-04-01T00:00:00Z',
+    updated_at: '2026-04-01T00:00:00Z',
+  };
+}
+
+function makeBill(
+  id: number,
+  payPeriodId: number,
+  amount: string,
+): PayPeriodBill {
+  return {
+    id,
+    pay_period_id: payPeriodId,
+    bill_template_id: null,
+    name: 'Rent',
+    amount,
+    due_date: null,
+    is_paid: false,
+    paid_date: null,
+    notes: null,
+    created_at: '2026-04-01T00:00:00Z',
+    updated_at: '2026-04-01T00:00:00Z',
+  };
+}
+
+function setupApiMock() {
+  vi.mocked(api.get).mockImplementation((url: string) => {
+    if (url === '/pay-periods') return Promise.resolve(mockPayPeriods);
+    if (url === '/categories') return Promise.resolve(mockCategories);
+    if (url === '/bills') return Promise.resolve(mockBills);
+    if (url === '/spending') return Promise.resolve(mockSpending);
+    return Promise.reject(new Error(`unexpected url: ${url}`));
+  });
+}
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+async function renderInsights(filter: InsightsFilter) {
+  setupApiMock();
+  const { result } = renderHook(() => useInsights(filter), {
+    wrapper: createWrapper(),
+  });
+  await waitFor(() => {
+    expect(result.current.data).toBeDefined();
+  });
+  return result;
+}
+
+describe('useInsights', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('range filtering', () => {
+    it("last-n: 6 returns the 6 most recent periods sorted oldest→newest", async () => {
+      const result = await renderInsights({
+        rangeMode: 'last-n',
+        n: 6,
+        include: 'both',
+      });
+      const ids = result.current.data!.periods.map((p) => p.id);
+      expect(ids).toEqual([1, 2, 3, 4, 5, 6]);
+    });
+
+    it('last-n: 3 trims to the 3 most recent periods', async () => {
+      const result = await renderInsights({
+        rangeMode: 'last-n',
+        n: 3,
+        include: 'both',
+      });
+      const ids = result.current.data!.periods.map((p) => p.id);
+      expect(ids).toEqual([4, 5, 6]);
+    });
+
+    it('custom range filters by start_date inclusive', async () => {
+      const result = await renderInsights({
+        rangeMode: 'custom',
+        fromDate: '2026-03-01',
+        toDate: '2026-04-19',
+        include: 'both',
+      });
+      const ids = result.current.data!.periods.map((p) => p.id);
+      expect(ids).toEqual([4, 5]);
+    });
+  });
+
+  describe('byCategory aggregation (spending only)', () => {
+    it('groups spending by category, sorted by total desc', async () => {
+      const result = await renderInsights({
+        rangeMode: 'last-n',
+        n: 3,
+        include: 'both',
+      });
+      const buckets = result.current.data!.byCategory;
+      // Periods 4, 5, 6: Food = 100+200=300; Travel = 50; Uncategorized = 30
+      expect(buckets.map((b) => [b.name, b.total])).toEqual([
+        ['Food', 300],
+        ['Travel', 50],
+        [UNCATEGORIZED, 30],
+      ]);
+    });
+
+    it('includes monthly_target on category buckets', async () => {
+      const result = await renderInsights({
+        rangeMode: 'last-n',
+        n: 3,
+        include: 'both',
+      });
+      const food = result.current.data!.byCategory.find(
+        (b) => b.name === 'Food',
+      );
+      expect(food?.target).toBe(500);
+      const travel = result.current.data!.byCategory.find(
+        (b) => b.name === 'Travel',
+      );
+      expect(travel?.target).toBeNull();
+    });
+
+    it('respects categoryIds filter (excludes Travel)', async () => {
+      const result = await renderInsights({
+        rangeMode: 'last-n',
+        n: 3,
+        categoryIds: [10],
+        include: 'both',
+      });
+      const names = result.current.data!.byCategory.map((b) => b.name);
+      // Travel is filtered out; uncategorized entry has category_id=null so also excluded
+      expect(names).toEqual(['Food']);
+    });
+  });
+
+  describe('include toggle', () => {
+    it("'spending' empties bills aggregations", async () => {
+      const result = await renderInsights({
+        rangeMode: 'last-n',
+        n: 3,
+        include: 'spending',
+      });
+      const billsTotals = result.current.data!.billsVsDiscretionary.map(
+        (b) => b.bills,
+      );
+      expect(billsTotals).toEqual([0, 0, 0]);
+    });
+
+    it("'bills' empties spending aggregations", async () => {
+      const result = await renderInsights({
+        rangeMode: 'last-n',
+        n: 3,
+        include: 'bills',
+      });
+      expect(result.current.data!.byCategory).toEqual([]);
+      const spendingTotals = result.current.data!.spendingByPeriod.map(
+        (s) => s.total,
+      );
+      expect(spendingTotals).toEqual([0, 0, 0]);
+    });
+  });
+
+  describe('grandTotal', () => {
+    it("sums all bills + spending in scope when include='both'", async () => {
+      const result = await renderInsights({
+        rangeMode: 'last-n',
+        n: 3,
+        include: 'both',
+      });
+      // Periods 4, 5, 6:
+      //   Spending: 100 + 50 + 200 + 30 = 380
+      //   Bills: 1500 + 1500 = 3000
+      //   Total: 3380
+      expect(result.current.data!.grandTotal).toBe(3380);
+    });
+  });
+
+  describe('amount range filter', () => {
+    it('respects minAmount + maxAmount', async () => {
+      const result = await renderInsights({
+        rangeMode: 'last-n',
+        n: 3,
+        include: 'spending',
+        minAmount: 40,
+        maxAmount: 150,
+      });
+      // Spending in last 3 periods within [40, 150]: 100 (Food P5), 50 (Travel P5)
+      // Excluded: 200 (>150), 30 (<40)
+      expect(result.current.data!.grandTotal).toBe(150);
+    });
+  });
+});
+
+const UNCATEGORIZED = 'Uncategorized';

--- a/frontend/src/hooks/useInsights.ts
+++ b/frontend/src/hooks/useInsights.ts
@@ -1,0 +1,267 @@
+import { useMemo } from 'react';
+import type {
+  Category,
+  PayPeriod,
+  PayPeriodBill,
+  SpendingEntry,
+} from '../types';
+import { formatDateRange, parseLocalDate } from '../utils/date';
+import { useAllBills } from './useBills';
+import { useCategories } from './useCategories';
+import { usePayPeriods } from './usePayPeriods';
+import { useAllSpending } from './useSpending';
+
+export type InsightsRangeMode = 'last-n' | 'ytd' | 'custom';
+export type InsightsInclude = 'bills' | 'spending' | 'both';
+
+export interface InsightsFilter {
+  rangeMode: InsightsRangeMode;
+  n?: number;
+  fromDate?: string;
+  toDate?: string;
+  categoryIds?: number[];
+  minAmount?: number;
+  maxAmount?: number;
+  include: InsightsInclude;
+}
+
+export interface InsightsCategoryBucket {
+  categoryId: number | null;
+  name: string;
+  color: string;
+  total: number;
+  target: number | null;
+}
+
+export interface InsightsPeriodBucket {
+  periodId: number;
+  label: string;
+  total: number;
+}
+
+export interface InsightsCategoryTrendBucket {
+  periodId: number;
+  label: string;
+  perCategory: Record<string, number>;
+}
+
+export interface InsightsBillsVsDiscretionaryBucket {
+  periodId: number;
+  label: string;
+  bills: number;
+  spending: number;
+}
+
+export interface InsightsData {
+  periods: PayPeriod[];
+  byCategory: InsightsCategoryBucket[];
+  spendingByPeriod: InsightsPeriodBucket[];
+  categoryTrend: InsightsCategoryTrendBucket[];
+  billsVsDiscretionary: InsightsBillsVsDiscretionaryBucket[];
+  grandTotal: number;
+}
+
+const UNCATEGORIZED_NAME = 'Uncategorized';
+const UNCATEGORIZED_COLOR = '#6b7280';
+const UNCATEGORIZED_KEY = 'uncategorized';
+
+export function useInsights(filter: InsightsFilter): {
+  data: InsightsData | undefined;
+  isLoading: boolean;
+} {
+  const periodsQuery = usePayPeriods();
+  const categoriesQuery = useCategories();
+  const billsQuery = useAllBills();
+  const spendingQuery = useAllSpending();
+
+  const isLoading =
+    periodsQuery.isLoading ||
+    categoriesQuery.isLoading ||
+    billsQuery.isLoading ||
+    spendingQuery.isLoading;
+
+  const periodsData = periodsQuery.data;
+  const categoriesData = categoriesQuery.data;
+  const billsData = billsQuery.data;
+  const spendingData = spendingQuery.data;
+
+  const data = useMemo<InsightsData | undefined>(() => {
+    if (!periodsData || !categoriesData || !billsData || !spendingData) {
+      return undefined;
+    }
+    return aggregate(filter, periodsData, categoriesData, billsData, spendingData);
+  }, [filter, periodsData, categoriesData, billsData, spendingData]);
+
+  return { data, isLoading };
+}
+
+function aggregate(
+  filter: InsightsFilter,
+  allPeriods: PayPeriod[],
+  categories: Category[],
+  allBills: PayPeriodBill[],
+  allSpending: SpendingEntry[],
+): InsightsData {
+  const periods = filterPeriods(filter, allPeriods);
+  const periodIds = new Set(periods.map((p) => p.id));
+
+  const includeBills = filter.include === 'bills' || filter.include === 'both';
+  const includeSpending =
+    filter.include === 'spending' || filter.include === 'both';
+
+  const bills = includeBills
+    ? allBills.filter((b) => billPasses(b, periodIds, filter))
+    : [];
+  const spending = includeSpending
+    ? allSpending.filter((e) => entryPasses(e, periodIds, filter))
+    : [];
+
+  const categoryMap = new Map<number, Category>(
+    categories.map((c) => [c.id, c]),
+  );
+
+  const totalsByCategory = new Map<number | null, number>();
+  for (const e of spending) {
+    const key = e.category_id;
+    totalsByCategory.set(
+      key,
+      (totalsByCategory.get(key) ?? 0) + Number(e.amount),
+    );
+  }
+
+  const byCategory: InsightsCategoryBucket[] = [];
+  for (const [catId, total] of totalsByCategory) {
+    if (catId === null) {
+      byCategory.push({
+        categoryId: null,
+        name: UNCATEGORIZED_NAME,
+        color: UNCATEGORIZED_COLOR,
+        total,
+        target: null,
+      });
+      continue;
+    }
+    const cat = categoryMap.get(catId);
+    if (!cat) continue;
+    byCategory.push({
+      categoryId: catId,
+      name: cat.name,
+      color: cat.color,
+      total,
+      target: cat.monthly_target ? Number(cat.monthly_target) : null,
+    });
+  }
+  byCategory.sort((a, b) => b.total - a.total);
+
+  const spendingByPeriodMap = new Map<number, number>();
+  for (const e of spending) {
+    spendingByPeriodMap.set(
+      e.pay_period_id,
+      (spendingByPeriodMap.get(e.pay_period_id) ?? 0) + Number(e.amount),
+    );
+  }
+  const billsByPeriodMap = new Map<number, number>();
+  for (const b of bills) {
+    billsByPeriodMap.set(
+      b.pay_period_id,
+      (billsByPeriodMap.get(b.pay_period_id) ?? 0) + Number(b.amount),
+    );
+  }
+
+  const spendingByPeriod: InsightsPeriodBucket[] = periods.map((p) => ({
+    periodId: p.id,
+    label: formatDateRange(p.start_date, p.end_date),
+    total: spendingByPeriodMap.get(p.id) ?? 0,
+  }));
+
+  const categoryTrend: InsightsCategoryTrendBucket[] = periods.map((p) => {
+    const perCategory: Record<string, number> = {};
+    for (const e of spending) {
+      if (e.pay_period_id !== p.id) continue;
+      const key =
+        e.category_id === null ? UNCATEGORIZED_KEY : String(e.category_id);
+      perCategory[key] = (perCategory[key] ?? 0) + Number(e.amount);
+    }
+    return {
+      periodId: p.id,
+      label: formatDateRange(p.start_date, p.end_date),
+      perCategory,
+    };
+  });
+
+  const billsVsDiscretionary: InsightsBillsVsDiscretionaryBucket[] = periods.map(
+    (p) => ({
+      periodId: p.id,
+      label: formatDateRange(p.start_date, p.end_date),
+      bills: billsByPeriodMap.get(p.id) ?? 0,
+      spending: spendingByPeriodMap.get(p.id) ?? 0,
+    }),
+  );
+
+  let grandTotal = 0;
+  for (const e of spending) grandTotal += Number(e.amount);
+  for (const b of bills) grandTotal += Number(b.amount);
+
+  return {
+    periods,
+    byCategory,
+    spendingByPeriod,
+    categoryTrend,
+    billsVsDiscretionary,
+    grandTotal,
+  };
+}
+
+function filterPeriods(
+  filter: InsightsFilter,
+  all: PayPeriod[],
+): PayPeriod[] {
+  const sorted = [...all].sort((a, b) =>
+    a.start_date.localeCompare(b.start_date),
+  );
+
+  if (filter.rangeMode === 'last-n') {
+    const n = filter.n ?? 6;
+    return sorted.slice(-n);
+  }
+  if (filter.rangeMode === 'ytd') {
+    const year = new Date().getFullYear();
+    return sorted.filter((p) => {
+      const end = parseLocalDate(p.end_date);
+      return end !== null && end.getFullYear() === year;
+    });
+  }
+  if (!filter.fromDate || !filter.toDate) return sorted;
+  return sorted.filter(
+    (p) => p.start_date >= filter.fromDate! && p.start_date <= filter.toDate!,
+  );
+}
+
+function billPasses(
+  b: PayPeriodBill,
+  periodIds: Set<number>,
+  filter: InsightsFilter,
+): boolean {
+  if (!periodIds.has(b.pay_period_id)) return false;
+  return amountInRange(Number(b.amount), filter);
+}
+
+function entryPasses(
+  e: SpendingEntry,
+  periodIds: Set<number>,
+  filter: InsightsFilter,
+): boolean {
+  if (!periodIds.has(e.pay_period_id)) return false;
+  if (filter.categoryIds && filter.categoryIds.length > 0) {
+    if (e.category_id === null || !filter.categoryIds.includes(e.category_id)) {
+      return false;
+    }
+  }
+  return amountInRange(Number(e.amount), filter);
+}
+
+function amountInRange(amount: number, filter: InsightsFilter): boolean {
+  if (filter.minAmount !== undefined && amount < filter.minAmount) return false;
+  if (filter.maxAmount !== undefined && amount > filter.maxAmount) return false;
+  return true;
+}

--- a/frontend/src/hooks/useSpending.ts
+++ b/frontend/src/hooks/useSpending.ts
@@ -11,6 +11,7 @@ export const spendingKeys = {
   all: ['spending'] as const,
   lists: () => [...spendingKeys.all, 'list'] as const,
   list: (payPeriodId: number) => [...spendingKeys.lists(), payPeriodId] as const,
+  allEntries: () => [...spendingKeys.all, 'all'] as const,
 };
 
 export function useSpending(payPeriodId: number | undefined) {
@@ -18,6 +19,13 @@ export function useSpending(payPeriodId: number | undefined) {
     queryKey: spendingKeys.list(payPeriodId!),
     queryFn: () => api.get<SpendingEntry[]>(`/pay-periods/${payPeriodId}/spending`),
     enabled: !!payPeriodId,
+  });
+}
+
+export function useAllSpending() {
+  return useQuery({
+    queryKey: spendingKeys.allEntries(),
+    queryFn: () => api.get<SpendingEntry[]>('/spending'),
   });
 }
 

--- a/frontend/src/pages/Insights.test.tsx
+++ b/frontend/src/pages/Insights.test.tsx
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactNode } from 'react';
+import { Insights } from './Insights';
+import { api } from '../services/api';
+import type {
+  Category,
+  PayPeriod,
+  PayPeriodBill,
+  SpendingEntry,
+} from '../types';
+
+vi.mock('../services/api', () => ({
+  api: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+const categories: Category[] = [
+  {
+    id: 10,
+    name: 'Food',
+    description: null,
+    color: '#f59e0b',
+    monthly_target: '500.00',
+    created_at: '2026-04-01T00:00:00Z',
+    updated_at: '2026-04-01T00:00:00Z',
+  },
+];
+
+const periods: PayPeriod[] = [
+  makePeriod(1, '2026-04-06', '2026-04-19'),
+  makePeriod(2, '2026-04-20', '2026-05-05'),
+];
+
+const spending: SpendingEntry[] = [
+  makeEntry(101, 1, 10, '100.00'),
+  makeEntry(102, 2, 10, '200.00'),
+];
+
+const bills: PayPeriodBill[] = [makeBill(201, 1, '1500.00')];
+
+function makePeriod(id: number, start: string, end: string): PayPeriod {
+  return {
+    id,
+    start_date: start,
+    end_date: end,
+    expected_income: '2500.00',
+    actual_income: null,
+    additional_income: null,
+    additional_income_description: null,
+    notes: null,
+    created_at: '2026-04-01T00:00:00Z',
+    updated_at: '2026-04-01T00:00:00Z',
+  };
+}
+
+function makeEntry(
+  id: number,
+  payPeriodId: number,
+  categoryId: number | null,
+  amount: string,
+): SpendingEntry {
+  return {
+    id,
+    pay_period_id: payPeriodId,
+    category_id: categoryId,
+    description: 'test',
+    amount,
+    spent_date: '2026-04-08',
+    notes: null,
+    created_at: '2026-04-01T00:00:00Z',
+    updated_at: '2026-04-01T00:00:00Z',
+  };
+}
+
+function makeBill(
+  id: number,
+  payPeriodId: number,
+  amount: string,
+): PayPeriodBill {
+  return {
+    id,
+    pay_period_id: payPeriodId,
+    bill_template_id: null,
+    name: 'Rent',
+    amount,
+    due_date: null,
+    is_paid: false,
+    paid_date: null,
+    notes: null,
+    created_at: '2026-04-01T00:00:00Z',
+    updated_at: '2026-04-01T00:00:00Z',
+  };
+}
+
+function setupApiMock() {
+  vi.mocked(api.get).mockImplementation((url: string) => {
+    if (url === '/pay-periods') return Promise.resolve(periods);
+    if (url === '/categories') return Promise.resolve(categories);
+    if (url === '/bills') return Promise.resolve(bills);
+    if (url === '/spending') return Promise.resolve(spending);
+    return Promise.reject(new Error(`unexpected url: ${url}`));
+  });
+}
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+describe('Insights page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupApiMock();
+  });
+
+  it('renders the page heading and toolbar', async () => {
+    render(<Insights />, { wrapper: createWrapper() });
+    expect(screen.getByRole('heading', { name: 'Insights' })).toBeInTheDocument();
+    expect(screen.getByLabelText('Range')).toBeInTheDocument();
+  });
+
+  it('shows summary counts after data loads', async () => {
+    render(<Insights />, { wrapper: createWrapper() });
+
+    expect(
+      await screen.findByTestId('insights-period-count'),
+    ).toHaveTextContent('2');
+    expect(screen.getByTestId('insights-category-count')).toHaveTextContent(
+      '1',
+    );
+    // 100 + 200 + 1500 = 1800
+    expect(screen.getByTestId('insights-grand-total')).toHaveTextContent(
+      '$1800.00',
+    );
+  });
+
+  it('updates the grand total when toggling Include to Bills only', async () => {
+    render(<Insights />, { wrapper: createWrapper() });
+
+    await screen.findByTestId('insights-grand-total');
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Bills' }));
+
+    // Wait for re-render with new aggregate
+    await screen.findByText('$1500.00');
+    expect(screen.getByTestId('insights-grand-total')).toHaveTextContent(
+      '$1500.00',
+    );
+  });
+});

--- a/frontend/src/pages/Insights.tsx
+++ b/frontend/src/pages/Insights.tsx
@@ -1,0 +1,67 @@
+import { useState } from 'react';
+import { InsightsToolbar } from '../components/InsightsToolbar';
+import { useCategories } from '../hooks/useCategories';
+import { useInsights, type InsightsFilter } from '../hooks/useInsights';
+
+const DEFAULT_FILTER: InsightsFilter = {
+  rangeMode: 'last-n',
+  n: 6,
+  include: 'both',
+  categoryIds: [],
+};
+
+export function Insights() {
+  const [filter, setFilter] = useState<InsightsFilter>(DEFAULT_FILTER);
+  const { data: categories } = useCategories();
+  const { data, isLoading } = useInsights(filter);
+
+  const periodCount = data?.periods.length ?? 0;
+  const categoryCount = data?.byCategory.length ?? 0;
+  const grandTotal = data?.grandTotal ?? 0;
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold">Insights</h1>
+        <p className="text-base-content/60 text-sm mt-1">
+          Filter and roll up your spending across pay periods. Charts coming
+          soon.
+        </p>
+      </div>
+
+      <InsightsToolbar
+        filter={filter}
+        onChange={setFilter}
+        categories={categories ?? []}
+      />
+
+      {isLoading ? (
+        <div className="flex justify-center py-12">
+          <span className="loading loading-spinner loading-lg" />
+        </div>
+      ) : (
+        <div className="card bg-base-100 shadow">
+          <div className="card-body">
+            <h2 className="card-title">Selected range</h2>
+            <p className="text-base">
+              <strong data-testid="insights-period-count">{periodCount}</strong>{' '}
+              pay period{periodCount === 1 ? '' : 's'} ·{' '}
+              <strong data-testid="insights-category-count">
+                {categoryCount}
+              </strong>{' '}
+              {categoryCount === 1 ? 'category' : 'categories'} ·{' '}
+              <strong data-testid="insights-grand-total">
+                ${grandTotal.toFixed(2)}
+              </strong>{' '}
+              total
+            </p>
+            <p className="text-base-content/60 mt-2 text-sm">
+              Charts (Spending by Category, Spending Over Time, Category Trend,
+              Bills vs Discretionary) land in upcoming PRs.
+            </p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
PR 2 of 5 in the Insights dashboard plan ([docs/dashboard-insights-implementation-plan.md](docs/dashboard-insights-implementation-plan.md)). Adds the foundation; charts come in PRs 3 + 4.

- **New `/insights` route + nav link** — separate page from the operational Dashboard
- **Filter toolbar** — range presets (Last 3/6/12, YTD, Custom), category multi-select dropdown w/ checkboxes, min/max amount, Include toggle (Bills / Spending / Both)
- **`useInsights` hook** — returns memoized aggregations: `byCategory` (with `monthly_target` from PR 1), `spendingByPeriod`, `categoryTrend`, `billsVsDiscretionary`, `grandTotal`. Pure aggregation, all client-side — single-user app, fits in memory.
- **Two new unfiltered list endpoints** — `GET /api/bills`, `GET /api/spending` so the hook can roll up across pay periods without N+1 fetches.
- Insights page renders a summary placeholder ("N pay periods · M categories · $X.XX total") so the wiring is visible end-to-end before charts arrive.

## Test plan
- [x] Backend: `pytest tests/` — **163 passed** (+4 new for `TestListAllBills` + `TestListAllSpending`)
- [x] Backend lint: `ruff check .` + `ruff format --check .` from `backend/` — clean (CI scope)
- [x] Frontend: `npm test` — **153 passed** (+23 new across `useInsights`, `InsightsToolbar`, `Insights`)
- [x] Frontend typecheck: `tsc --noEmit` — clean
- [ ] Manual smoke: navigate to `/insights`, verify toolbar renders, range/category/include changes update the summary, custom range shows date pickers

## Out of scope (later PRs)
- PR 3: Spending by Category donut + Spending Over Time line
- PR 4: Category Trend stacked + Bills vs Discretionary + budget overlay
- PR 5 (optional): Monthly rollup toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)