### PR TITLE
feat: add Spending by Category and Spending Over Time charts

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,19 +1,20 @@
 {
   "name": "rae-budget-frontend",
-  "version": "0.1.0",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rae-budget-frontend",
-      "version": "0.1.0",
+      "version": "0.1.5",
       "hasInstallScript": true,
       "dependencies": {
         "@tanstack/react-form": "^1.0.0",
         "@tanstack/react-query": "^5.60.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "react-router-dom": "^7.14.0"
+        "react-router-dom": "^7.14.0",
+        "recharts": "^3.8.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.15.0",
@@ -1186,6 +1187,42 @@
         "node": ">=14"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -1516,6 +1553,18 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
     },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.4",
@@ -2026,6 +2075,69 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -2048,7 +2160,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2061,6 +2173,12 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.59.0",
@@ -2789,6 +2907,15 @@
         "node": ">= 16"
       }
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2868,7 +2995,128 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true
+      "devOptional": true
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/daisyui": {
       "version": "5.5.19",
@@ -2914,6 +3162,12 @@
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
       "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
       "dev": true
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/deep-eql": {
       "version": "5.0.2",
@@ -3002,6 +3256,16 @@
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.46.0",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.46.0.tgz",
+      "integrity": "sha512-IToJ6ct9OLl5zz6WsC/1vZEwfSZ7Myil+ygl5Tf30Xjn9AEkzNB4kqp2G7VUJKF1DtTx/ra5M5KLlXvzOg51BA==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
@@ -3240,6 +3504,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/expect-type": {
       "version": "1.3.0",
@@ -3533,6 +3803,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -3565,6 +3845,15 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-extglob": {
@@ -4467,8 +4756,30 @@
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
-      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -4515,6 +4826,36 @@
         "react-dom": ">=18"
       }
     },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -4527,6 +4868,27 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -4903,6 +5265,12 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -5105,6 +5473,28 @@
       "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,8 @@
     "@tanstack/react-query": "^5.60.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-router-dom": "^7.14.0"
+    "react-router-dom": "^7.14.0",
+    "recharts": "^3.8.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.15.0",

--- a/frontend/src/components/insights/ChartCard.tsx
+++ b/frontend/src/components/insights/ChartCard.tsx
@@ -1,0 +1,26 @@
+import type { ReactNode } from 'react';
+
+export function ChartCard({
+  title,
+  children,
+}: {
+  title: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="card bg-base-100 shadow">
+      <div className="card-body">
+        <h2 className="card-title">{title}</h2>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+export function ChartEmptyState({ message }: { message: string }) {
+  return (
+    <div className="flex items-center justify-center h-64 text-base-content/60">
+      {message}
+    </div>
+  );
+}

--- a/frontend/src/components/insights/SpendingByCategoryChart.test.tsx
+++ b/frontend/src/components/insights/SpendingByCategoryChart.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { cloneElement, type ReactElement } from 'react';
+import { SpendingByCategoryChart } from './SpendingByCategoryChart';
+import type { InsightsCategoryBucket } from '../../hooks/useInsights';
+
+// jsdom doesn't compute layout, so ResponsiveContainer can't size its child.
+// Bypass it: clone the wrapped chart with explicit width/height so Recharts
+// has dimensions to render against.
+vi.mock('recharts', async (importActual) => {
+  const actual = await importActual<typeof import('recharts')>();
+  return {
+    ...actual,
+    ResponsiveContainer: ({
+      children,
+    }: {
+      children: ReactElement<{ width?: number; height?: number }>;
+    }) => cloneElement(children, { width: 600, height: 300 }),
+  };
+});
+
+const buckets: InsightsCategoryBucket[] = [
+  {
+    categoryId: 10,
+    name: 'Food',
+    color: '#f59e0b',
+    total: 300,
+    target: 500,
+  },
+  {
+    categoryId: 20,
+    name: 'Travel',
+    color: '#3b82f6',
+    total: 50,
+    target: null,
+  },
+];
+
+describe('SpendingByCategoryChart', () => {
+  it('renders the empty state when no data', () => {
+    render(<SpendingByCategoryChart data={[]} grandTotal={0} />);
+    expect(screen.getByText(/No spending in the selected range/)).toBeInTheDocument();
+  });
+
+  it('renders the chart card with title when data is present', () => {
+    render(<SpendingByCategoryChart data={buckets} grandTotal={350} />);
+    expect(
+      screen.getByRole('heading', { name: 'Spending by Category' }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders a Recharts pie SVG when data is present', () => {
+    const { container } = render(
+      <SpendingByCategoryChart data={buckets} grandTotal={350} />,
+    );
+    // jsdom doesn't compute layout, so legend/tooltip text is absent — but the
+    // SVG container and pie group are emitted. That's enough to prove the
+    // component wired Recharts correctly.
+    expect(container.querySelector('svg')).toBeInTheDocument();
+    expect(container.querySelector('.recharts-pie')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/insights/SpendingByCategoryChart.tsx
+++ b/frontend/src/components/insights/SpendingByCategoryChart.tsx
@@ -1,0 +1,59 @@
+import {
+  Cell,
+  Legend,
+  Pie,
+  PieChart,
+  ResponsiveContainer,
+  Tooltip,
+} from 'recharts';
+import type { InsightsCategoryBucket } from '../../hooks/useInsights';
+import { ChartCard, ChartEmptyState } from './ChartCard';
+
+interface Props {
+  data: InsightsCategoryBucket[];
+  grandTotal: number;
+}
+
+export function SpendingByCategoryChart({ data, grandTotal }: Props) {
+  if (data.length === 0) {
+    return (
+      <ChartCard title="Spending by Category">
+        <ChartEmptyState message="No spending in the selected range." />
+      </ChartCard>
+    );
+  }
+
+  const total = grandTotal > 0 ? grandTotal : data.reduce((s, d) => s + d.total, 0);
+
+  return (
+    <ChartCard title="Spending by Category">
+      <ResponsiveContainer width="100%" height={300}>
+        <PieChart>
+          <Pie
+            data={data}
+            dataKey="total"
+            nameKey="name"
+            innerRadius={60}
+            outerRadius={100}
+            paddingAngle={2}
+          >
+            {data.map((entry) => (
+              <Cell
+                key={entry.categoryId ?? 'uncategorized'}
+                fill={entry.color}
+              />
+            ))}
+          </Pie>
+          <Tooltip
+            formatter={(value, name) => {
+              const num = typeof value === 'number' ? value : 0;
+              const pct = total > 0 ? ((num / total) * 100).toFixed(1) : '0.0';
+              return [`$${num.toFixed(2)} (${pct}%)`, String(name)];
+            }}
+          />
+          <Legend verticalAlign="bottom" height={36} />
+        </PieChart>
+      </ResponsiveContainer>
+    </ChartCard>
+  );
+}

--- a/frontend/src/components/insights/SpendingOverTimeChart.test.tsx
+++ b/frontend/src/components/insights/SpendingOverTimeChart.test.tsx
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { cloneElement, type ReactElement } from 'react';
+import { SpendingOverTimeChart } from './SpendingOverTimeChart';
+import type { InsightsPeriodBucket } from '../../hooks/useInsights';
+
+vi.mock('recharts', async (importActual) => {
+  const actual = await importActual<typeof import('recharts')>();
+  return {
+    ...actual,
+    ResponsiveContainer: ({
+      children,
+    }: {
+      children: ReactElement<{ width?: number; height?: number }>;
+    }) => cloneElement(children, { width: 600, height: 300 }),
+  };
+});
+
+const buckets: InsightsPeriodBucket[] = [
+  { periodId: 1, label: 'Apr 6 - Apr 19, 2026', total: 100 },
+  { periodId: 2, label: 'Apr 20 - May 5, 2026', total: 250 },
+];
+
+describe('SpendingOverTimeChart', () => {
+  it('renders the empty state when no data', () => {
+    render(<SpendingOverTimeChart data={[]} />);
+    expect(
+      screen.getByText(/No pay periods in the selected range/),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the chart card with title when data is present', () => {
+    render(<SpendingOverTimeChart data={buckets} />);
+    expect(
+      screen.getByRole('heading', { name: 'Spending Over Time' }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders a Recharts area SVG when data is present', () => {
+    const { container } = render(<SpendingOverTimeChart data={buckets} />);
+    expect(container.querySelector('svg')).toBeInTheDocument();
+    expect(container.querySelector('.recharts-area')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/insights/SpendingOverTimeChart.tsx
+++ b/frontend/src/components/insights/SpendingOverTimeChart.tsx
@@ -1,0 +1,62 @@
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import type { InsightsPeriodBucket } from '../../hooks/useInsights';
+import { ChartCard, ChartEmptyState } from './ChartCard';
+
+interface Props {
+  data: InsightsPeriodBucket[];
+}
+
+export function SpendingOverTimeChart({ data }: Props) {
+  if (data.length === 0) {
+    return (
+      <ChartCard title="Spending Over Time">
+        <ChartEmptyState message="No pay periods in the selected range." />
+      </ChartCard>
+    );
+  }
+
+  return (
+    <ChartCard title="Spending Over Time">
+      <ResponsiveContainer width="100%" height={300}>
+        <AreaChart
+          data={data}
+          margin={{ top: 8, right: 16, left: 0, bottom: 0 }}
+        >
+          <defs>
+            <linearGradient id="spendingGradient" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="5%" stopColor="#3b82f6" stopOpacity={0.5} />
+              <stop offset="95%" stopColor="#3b82f6" stopOpacity={0} />
+            </linearGradient>
+          </defs>
+          <CartesianGrid strokeDasharray="3 3" opacity={0.3} />
+          <XAxis dataKey="label" tick={{ fontSize: 11 }} />
+          <YAxis
+            tickFormatter={(v: number) => `$${v}`}
+            tick={{ fontSize: 11 }}
+          />
+          <Tooltip
+            formatter={(value) => {
+              const num = typeof value === 'number' ? value : 0;
+              return [`$${num.toFixed(2)}`, 'Total'];
+            }}
+          />
+          <Area
+            type="monotone"
+            dataKey="total"
+            stroke="#3b82f6"
+            strokeWidth={2}
+            fill="url(#spendingGradient)"
+          />
+        </AreaChart>
+      </ResponsiveContainer>
+    </ChartCard>
+  );
+}

--- a/frontend/src/pages/Insights.test.tsx
+++ b/frontend/src/pages/Insights.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { ReactNode } from 'react';
+import { cloneElement, type ReactElement, type ReactNode } from 'react';
 import { Insights } from './Insights';
 import { api } from '../services/api';
 import type {
@@ -19,6 +19,18 @@ vi.mock('../services/api', () => ({
     delete: vi.fn(),
   },
 }));
+
+vi.mock('recharts', async (importActual) => {
+  const actual = await importActual<typeof import('recharts')>();
+  return {
+    ...actual,
+    ResponsiveContainer: ({
+      children,
+    }: {
+      children: ReactElement<{ width?: number; height?: number }>;
+    }) => cloneElement(children, { width: 600, height: 300 }),
+  };
+});
 
 const categories: Category[] = [
   {
@@ -134,9 +146,11 @@ describe('Insights page', () => {
   it('shows summary counts after data loads', async () => {
     render(<Insights />, { wrapper: createWrapper() });
 
-    expect(
-      await screen.findByTestId('insights-period-count'),
-    ).toHaveTextContent('2');
+    await waitFor(() => {
+      expect(screen.getByTestId('insights-period-count')).toHaveTextContent(
+        '2',
+      );
+    });
     expect(screen.getByTestId('insights-category-count')).toHaveTextContent(
       '1',
     );
@@ -149,14 +163,18 @@ describe('Insights page', () => {
   it('updates the grand total when toggling Include to Bills only', async () => {
     render(<Insights />, { wrapper: createWrapper() });
 
-    await screen.findByTestId('insights-grand-total');
+    await waitFor(() => {
+      expect(screen.getByTestId('insights-grand-total')).toHaveTextContent(
+        '$1800.00',
+      );
+    });
 
     fireEvent.click(screen.getByRole('radio', { name: 'Bills' }));
 
-    // Wait for re-render with new aggregate
-    await screen.findByText('$1500.00');
-    expect(screen.getByTestId('insights-grand-total')).toHaveTextContent(
-      '$1500.00',
-    );
+    await waitFor(() => {
+      expect(screen.getByTestId('insights-grand-total')).toHaveTextContent(
+        '$1500.00',
+      );
+    });
   });
 });

--- a/frontend/src/pages/Insights.tsx
+++ b/frontend/src/pages/Insights.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react';
 import { InsightsToolbar } from '../components/InsightsToolbar';
+import { SpendingByCategoryChart } from '../components/insights/SpendingByCategoryChart';
+import { SpendingOverTimeChart } from '../components/insights/SpendingOverTimeChart';
 import { useCategories } from '../hooks/useCategories';
 import { useInsights, type InsightsFilter } from '../hooks/useInsights';
 
@@ -24,8 +26,7 @@ export function Insights() {
       <div>
         <h1 className="text-2xl font-bold">Insights</h1>
         <p className="text-base-content/60 text-sm mt-1">
-          Filter and roll up your spending across pay periods. Charts coming
-          soon.
+          Filter and roll up your spending across pay periods.
         </p>
       </div>
 
@@ -35,33 +36,31 @@ export function Insights() {
         categories={categories ?? []}
       />
 
+      {/* Summary strip */}
+      <div className="text-sm text-base-content/70">
+        <strong data-testid="insights-period-count">{periodCount}</strong>{' '}
+        pay period{periodCount === 1 ? '' : 's'} ·{' '}
+        <strong data-testid="insights-category-count">{categoryCount}</strong>{' '}
+        {categoryCount === 1 ? 'category' : 'categories'} ·{' '}
+        <strong data-testid="insights-grand-total">
+          ${grandTotal.toFixed(2)}
+        </strong>{' '}
+        total
+      </div>
+
       {isLoading ? (
         <div className="flex justify-center py-12">
           <span className="loading loading-spinner loading-lg" />
         </div>
-      ) : (
-        <div className="card bg-base-100 shadow">
-          <div className="card-body">
-            <h2 className="card-title">Selected range</h2>
-            <p className="text-base">
-              <strong data-testid="insights-period-count">{periodCount}</strong>{' '}
-              pay period{periodCount === 1 ? '' : 's'} ·{' '}
-              <strong data-testid="insights-category-count">
-                {categoryCount}
-              </strong>{' '}
-              {categoryCount === 1 ? 'category' : 'categories'} ·{' '}
-              <strong data-testid="insights-grand-total">
-                ${grandTotal.toFixed(2)}
-              </strong>{' '}
-              total
-            </p>
-            <p className="text-base-content/60 mt-2 text-sm">
-              Charts (Spending by Category, Spending Over Time, Category Trend,
-              Bills vs Discretionary) land in upcoming PRs.
-            </p>
-          </div>
+      ) : data ? (
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          <SpendingByCategoryChart
+            data={data.byCategory}
+            grandTotal={data.grandTotal}
+          />
+          <SpendingOverTimeChart data={data.spendingByPeriod} />
         </div>
-      )}
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
PR 3 of 5 in the Insights dashboard plan. Lights up the first two charts; PR 4 adds the remaining two with the budget-vs-actual overlay.

- **Spending by Category** — Recharts donut, colors taken from each category's own `color` field, tooltip shows `$total` and `% of grand total`
- **Spending Over Time** — Recharts area chart with gradient fill; X-axis = period label (e.g. `Apr 6 - Apr 19, 2026`), Y-axis = `$`
- **Shared `ChartCard` shell** + empty-state component so the next two charts in PR 4 can drop in cleanly
- Insights page replaces the summary placeholder with a 2-column responsive grid; the summary stays as a thin info strip above the charts
- New dependency: `recharts ^3.8.1` (~100KB gzipped, no design system clash with DaisyUI)

## Test plan
- [x] Frontend tests: `npm test` — **159 passed** (+6 new for chart components and the updated Insights page)
- [x] Frontend lint: `eslint .` — clean (only pre-existing warnings in `test/utils.tsx`)
- [x] Frontend typecheck: `tsc --noEmit` — clean
- [x] Frontend build: `vite build` succeeds; bundle is ~720KB (chunk-size warning is informational, can be code-split later if it bothers anyone)
- [ ] Manual smoke: navigate to `/insights`, verify both charts render with real data, tooltips show correct values, empty state appears when filtering away all data

## Notes for reviewers
- Tests use a small `cloneElement` shim for Recharts' `ResponsiveContainer` so charts get explicit dimensions in jsdom (jsdom can't compute layout). All chart tests use this pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)