### PR TITLE
feat: add Category Trend and Bills vs Discretionary charts with budget overlay

### DIFF
--- a/frontend/src/components/insights/BillsVsDiscretionaryChart.test.tsx
+++ b/frontend/src/components/insights/BillsVsDiscretionaryChart.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { cloneElement, type ReactElement } from 'react';
+import { BillsVsDiscretionaryChart } from './BillsVsDiscretionaryChart';
+import type { InsightsBillsVsDiscretionaryBucket } from '../../hooks/useInsights';
+
+vi.mock('recharts', async (importActual) => {
+  const actual = await importActual<typeof import('recharts')>();
+  return {
+    ...actual,
+    ResponsiveContainer: ({
+      children,
+    }: {
+      children: ReactElement<{ width?: number; height?: number }>;
+    }) => cloneElement(children, { width: 600, height: 300 }),
+  };
+});
+
+const data: InsightsBillsVsDiscretionaryBucket[] = [
+  {
+    periodId: 1,
+    label: 'Apr 6 - Apr 19, 2026',
+    bills: 1500,
+    spending: 150,
+  },
+  {
+    periodId: 2,
+    label: 'Apr 20 - May 5, 2026',
+    bills: 1500,
+    spending: 200,
+  },
+];
+
+describe('BillsVsDiscretionaryChart', () => {
+  it('renders empty state when no data', () => {
+    render(<BillsVsDiscretionaryChart data={[]} />);
+    expect(
+      screen.getByText(/No pay periods in the selected range/),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the chart card with title when data is present', () => {
+    render(<BillsVsDiscretionaryChart data={data} />);
+    expect(
+      screen.getByRole('heading', { name: 'Bills vs Discretionary' }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders two Recharts line series', () => {
+    const { container } = render(<BillsVsDiscretionaryChart data={data} />);
+    expect(container.querySelector('svg')).toBeInTheDocument();
+    expect(container.querySelectorAll('.recharts-line').length).toBe(2);
+  });
+});

--- a/frontend/src/components/insights/BillsVsDiscretionaryChart.tsx
+++ b/frontend/src/components/insights/BillsVsDiscretionaryChart.tsx
@@ -1,0 +1,77 @@
+import {
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import type { InsightsBillsVsDiscretionaryBucket } from '../../hooks/useInsights';
+import { ChartCard, ChartEmptyState } from './ChartCard';
+
+interface Props {
+  data: InsightsBillsVsDiscretionaryBucket[];
+}
+
+const SERIES_LABELS: Record<string, string> = {
+  bills: 'Bills',
+  spending: 'Discretionary',
+};
+
+export function BillsVsDiscretionaryChart({ data }: Props) {
+  if (data.length === 0) {
+    return (
+      <ChartCard title="Bills vs Discretionary">
+        <ChartEmptyState message="No pay periods in the selected range." />
+      </ChartCard>
+    );
+  }
+
+  return (
+    <ChartCard title="Bills vs Discretionary">
+      <ResponsiveContainer width="100%" height={300}>
+        <LineChart
+          data={data}
+          margin={{ top: 8, right: 16, left: 0, bottom: 0 }}
+        >
+          <CartesianGrid strokeDasharray="3 3" opacity={0.3} />
+          <XAxis dataKey="label" tick={{ fontSize: 11 }} />
+          <YAxis
+            tickFormatter={(v: number) => `$${v}`}
+            tick={{ fontSize: 11 }}
+          />
+          <Tooltip
+            formatter={(value, name) => {
+              const num = typeof value === 'number' ? value : 0;
+              return [
+                `$${num.toFixed(2)}`,
+                SERIES_LABELS[String(name)] ?? String(name),
+              ];
+            }}
+          />
+          <Legend
+            verticalAlign="bottom"
+            height={36}
+            formatter={(value) => SERIES_LABELS[String(value)] ?? value}
+          />
+          <Line
+            type="monotone"
+            dataKey="bills"
+            stroke="#ef4444"
+            strokeWidth={2}
+            dot={{ r: 3 }}
+          />
+          <Line
+            type="monotone"
+            dataKey="spending"
+            stroke="#3b82f6"
+            strokeWidth={2}
+            dot={{ r: 3 }}
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    </ChartCard>
+  );
+}

--- a/frontend/src/components/insights/CategoryTrendChart.test.tsx
+++ b/frontend/src/components/insights/CategoryTrendChart.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { cloneElement, type ReactElement } from 'react';
+import { CategoryTrendChart } from './CategoryTrendChart';
+import type {
+  InsightsCategoryBucket,
+  InsightsCategoryTrendBucket,
+} from '../../hooks/useInsights';
+
+vi.mock('recharts', async (importActual) => {
+  const actual = await importActual<typeof import('recharts')>();
+  return {
+    ...actual,
+    ResponsiveContainer: ({
+      children,
+    }: {
+      children: ReactElement<{ width?: number; height?: number }>;
+    }) => cloneElement(children, { width: 600, height: 300 }),
+  };
+});
+
+const byCategory: InsightsCategoryBucket[] = [
+  { categoryId: 10, name: 'Food', color: '#f59e0b', total: 300, target: 500 },
+  { categoryId: 20, name: 'Travel', color: '#3b82f6', total: 50, target: null },
+];
+
+const trend: InsightsCategoryTrendBucket[] = [
+  {
+    periodId: 1,
+    label: 'Apr 6 - Apr 19, 2026',
+    perCategory: { '10': 100, '20': 50 },
+  },
+  {
+    periodId: 2,
+    label: 'Apr 20 - May 5, 2026',
+    perCategory: { '10': 200 },
+  },
+];
+
+describe('CategoryTrendChart', () => {
+  it('renders empty state when no trend data', () => {
+    render(<CategoryTrendChart data={[]} byCategory={byCategory} />);
+    expect(
+      screen.getByText(/No spending in the selected range/),
+    ).toBeInTheDocument();
+  });
+
+  it('renders empty state when no categories', () => {
+    render(<CategoryTrendChart data={trend} byCategory={[]} />);
+    expect(
+      screen.getByText(/No spending in the selected range/),
+    ).toBeInTheDocument();
+  });
+
+  it('renders the chart card with title when data is present', () => {
+    render(<CategoryTrendChart data={trend} byCategory={byCategory} />);
+    expect(
+      screen.getByRole('heading', { name: 'Category Trend' }),
+    ).toBeInTheDocument();
+  });
+
+  it('renders Recharts bars and a reference line for categories with targets', () => {
+    const { container } = render(
+      <CategoryTrendChart data={trend} byCategory={byCategory} />,
+    );
+    expect(container.querySelector('svg')).toBeInTheDocument();
+    // One stacked bar per period; multiple .recharts-bar groups expected
+    expect(container.querySelectorAll('.recharts-bar').length).toBeGreaterThan(
+      0,
+    );
+    // Food has a target → reference line present
+    expect(
+      container.querySelector('.recharts-reference-line'),
+    ).toBeInTheDocument();
+  });
+
+  it('does not render any reference line when no category has a target', () => {
+    const noTargets: InsightsCategoryBucket[] = byCategory.map((b) => ({
+      ...b,
+      target: null,
+    }));
+    const { container } = render(
+      <CategoryTrendChart data={trend} byCategory={noTargets} />,
+    );
+    expect(
+      container.querySelector('.recharts-reference-line'),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/insights/CategoryTrendChart.tsx
+++ b/frontend/src/components/insights/CategoryTrendChart.tsx
@@ -1,0 +1,110 @@
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Legend,
+  ReferenceLine,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import type {
+  InsightsCategoryBucket,
+  InsightsCategoryTrendBucket,
+} from '../../hooks/useInsights';
+import { ChartCard, ChartEmptyState } from './ChartCard';
+
+interface Props {
+  data: InsightsCategoryTrendBucket[];
+  byCategory: InsightsCategoryBucket[];
+}
+
+interface FlatRow {
+  label: string;
+  [categoryKey: string]: number | string;
+}
+
+function categoryKey(b: InsightsCategoryBucket): string {
+  return b.categoryId === null ? 'uncategorized' : String(b.categoryId);
+}
+
+export function CategoryTrendChart({ data, byCategory }: Props) {
+  if (data.length === 0 || byCategory.length === 0) {
+    return (
+      <ChartCard title="Category Trend">
+        <ChartEmptyState message="No spending in the selected range." />
+      </ChartCard>
+    );
+  }
+
+  const rows: FlatRow[] = data.map((row) => {
+    const flat: FlatRow = { label: row.label };
+    for (const bucket of byCategory) {
+      flat[categoryKey(bucket)] = row.perCategory[categoryKey(bucket)] ?? 0;
+    }
+    return flat;
+  });
+
+  const periodCount = data.length;
+
+  return (
+    <ChartCard title="Category Trend">
+      <ResponsiveContainer width="100%" height={300}>
+        <BarChart
+          data={rows}
+          margin={{ top: 8, right: 16, left: 0, bottom: 0 }}
+        >
+          <CartesianGrid strokeDasharray="3 3" opacity={0.3} />
+          <XAxis dataKey="label" tick={{ fontSize: 11 }} />
+          <YAxis
+            tickFormatter={(v: number) => `$${v}`}
+            tick={{ fontSize: 11 }}
+          />
+          <Tooltip
+            formatter={(value, name) => {
+              const num = typeof value === 'number' ? value : 0;
+              const bucket = byCategory.find((b) => categoryKey(b) === name);
+              return [`$${num.toFixed(2)}`, bucket?.name ?? String(name)];
+            }}
+          />
+          <Legend
+            verticalAlign="bottom"
+            height={36}
+            formatter={(value) => {
+              const bucket = byCategory.find(
+                (b) => categoryKey(b) === value,
+              );
+              return bucket?.name ?? value;
+            }}
+          />
+          {byCategory.map((bucket) => (
+            <Bar
+              key={categoryKey(bucket)}
+              dataKey={categoryKey(bucket)}
+              stackId="categories"
+              fill={bucket.color}
+            />
+          ))}
+          {byCategory
+            .filter((b) => b.target !== null && periodCount > 0)
+            .map((b) => (
+              <ReferenceLine
+                key={`target-${categoryKey(b)}`}
+                y={b.target! / 2}
+                stroke={b.color}
+                strokeDasharray="4 2"
+                label={{
+                  value: `${b.name} target`,
+                  position: 'right',
+                  fontSize: 10,
+                  fill: b.color,
+                }}
+                ifOverflow="extendDomain"
+              />
+            ))}
+        </BarChart>
+      </ResponsiveContainer>
+    </ChartCard>
+  );
+}

--- a/frontend/src/components/insights/SpendingByCategoryChart.test.tsx
+++ b/frontend/src/components/insights/SpendingByCategoryChart.test.tsx
@@ -38,12 +38,12 @@ const buckets: InsightsCategoryBucket[] = [
 
 describe('SpendingByCategoryChart', () => {
   it('renders the empty state when no data', () => {
-    render(<SpendingByCategoryChart data={[]} grandTotal={0} />);
+    render(<SpendingByCategoryChart data={[]} grandTotal={0} periodCount={0} />);
     expect(screen.getByText(/No spending in the selected range/)).toBeInTheDocument();
   });
 
   it('renders the chart card with title when data is present', () => {
-    render(<SpendingByCategoryChart data={buckets} grandTotal={350} />);
+    render(<SpendingByCategoryChart data={buckets} grandTotal={350} periodCount={2} />);
     expect(
       screen.getByRole('heading', { name: 'Spending by Category' }),
     ).toBeInTheDocument();
@@ -51,7 +51,7 @@ describe('SpendingByCategoryChart', () => {
 
   it('renders a Recharts pie SVG when data is present', () => {
     const { container } = render(
-      <SpendingByCategoryChart data={buckets} grandTotal={350} />,
+      <SpendingByCategoryChart data={buckets} grandTotal={350} periodCount={2} />,
     );
     // jsdom doesn't compute layout, so legend/tooltip text is absent — but the
     // SVG container and pie group are emitted. That's enough to prove the

--- a/frontend/src/components/insights/SpendingByCategoryChart.tsx
+++ b/frontend/src/components/insights/SpendingByCategoryChart.tsx
@@ -12,9 +12,14 @@ import { ChartCard, ChartEmptyState } from './ChartCard';
 interface Props {
   data: InsightsCategoryBucket[];
   grandTotal: number;
+  periodCount: number;
 }
 
-export function SpendingByCategoryChart({ data, grandTotal }: Props) {
+export function SpendingByCategoryChart({
+  data,
+  grandTotal,
+  periodCount,
+}: Props) {
   if (data.length === 0) {
     return (
       <ChartCard title="Spending by Category">
@@ -45,9 +50,21 @@ export function SpendingByCategoryChart({ data, grandTotal }: Props) {
             ))}
           </Pie>
           <Tooltip
-            formatter={(value, name) => {
+            formatter={(value, name, item) => {
               const num = typeof value === 'number' ? value : 0;
               const pct = total > 0 ? ((num / total) * 100).toFixed(1) : '0.0';
+              const bucket = item?.payload as
+                | InsightsCategoryBucket
+                | undefined;
+              if (bucket?.target && periodCount > 0) {
+                // Two pay periods per month; selected range covers periodCount/2 months.
+                const expected = (bucket.target * periodCount) / 2;
+                const ratio = expected > 0 ? (num / expected) * 100 : 0;
+                return [
+                  `$${num.toFixed(2)} (${pct}%) — ${ratio.toFixed(0)}% of $${expected.toFixed(2)} target`,
+                  String(name),
+                ];
+              }
               return [`$${num.toFixed(2)} (${pct}%)`, String(name)];
             }}
           />

--- a/frontend/src/pages/Insights.tsx
+++ b/frontend/src/pages/Insights.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react';
 import { InsightsToolbar } from '../components/InsightsToolbar';
+import { BillsVsDiscretionaryChart } from '../components/insights/BillsVsDiscretionaryChart';
+import { CategoryTrendChart } from '../components/insights/CategoryTrendChart';
 import { SpendingByCategoryChart } from '../components/insights/SpendingByCategoryChart';
 import { SpendingOverTimeChart } from '../components/insights/SpendingOverTimeChart';
 import { useCategories } from '../hooks/useCategories';
@@ -57,8 +59,14 @@ export function Insights() {
           <SpendingByCategoryChart
             data={data.byCategory}
             grandTotal={data.grandTotal}
+            periodCount={data.periods.length}
           />
           <SpendingOverTimeChart data={data.spendingByPeriod} />
+          <CategoryTrendChart
+            data={data.categoryTrend}
+            byCategory={data.byCategory}
+          />
+          <BillsVsDiscretionaryChart data={data.billsVsDiscretionary} />
         </div>
       ) : null}
     </div>


### PR DESCRIPTION
## Summary
PR 4 of 5 in the Insights dashboard plan. The four-chart set is now complete; PR 5 (optional) is the monthly rollup toggle.

This PR also finally cashes in PR 1's `monthly_target` column with the budget overlay.

- **Category Trend** — Recharts stacked BarChart, one bar per period, one stack segment per category. Colors come from each category's own `color` field. Horizontal `ReferenceLine` drawn at `monthly_target / 2` for every category that has a target set (one pay period's share of the monthly budget). Categories with no target are unaffected.
- **Bills vs Discretionary** — Recharts LineChart with two series (`bills` red, `spending` blue) so fixed cost vs discretionary spend is visible at a glance.
- **Donut tooltip extension** — when hovering a slice whose category has a target, the tooltip now shows the `actual / expected_for_range` ratio (where `expected = monthly_target × periodCount / 2`). Slices without a target keep their original `$total (X% of grand total)` format.
- Insights page extends to a 2×2 responsive grid; collapses to a single column on mobile.

## Test plan
- [x] Frontend tests: `npm test` — **167 passed** (+8 new for the two charts and the donut prop change)
- [x] Frontend lint: `eslint .` — clean (only pre-existing warnings in `test/utils.tsx`)
- [x] Frontend typecheck: `tsc --noEmit` — clean
- [x] Frontend build: `vite build` succeeds (~720KB bundle, chunk-size warning is informational)
- [ ] Manual smoke: navigate to `/insights`, confirm all four charts render at once, set a `monthly_target` on a category and verify the dashed reference line appears in Category Trend + the budget ratio shows in the donut tooltip

## What's next
- **PR 5 (optional):** Monthly rollup toggle in the toolbar — groups consecutive periods into calendar months. Skip if pay-period granularity feels right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)