### PR TITLE
feat: include monthly_target and additional_income in export/import

### DIFF
--- a/backend/app/routes/data_management.py
+++ b/backend/app/routes/data_management.py
@@ -42,6 +42,7 @@ def export_data():
                 name=c.name,
                 description=c.description,
                 color=c.color,
+                monthly_target=c.monthly_target,
             )
             for c in categories
         ]
@@ -104,6 +105,8 @@ def export_data():
                     end_date=pp.end_date,
                     expected_income=pp.expected_income,
                     actual_income=pp.actual_income,
+                    additional_income=pp.additional_income,
+                    additional_income_description=pp.additional_income_description,
                     notes=pp.notes,
                     bills=bills,
                     spending_entries=spending_entries,
@@ -170,6 +173,7 @@ def import_data():
                     name=cat_data.name,
                     description=cat_data.description,
                     color=cat_data.color,
+                    monthly_target=cat_data.monthly_target,
                 )
                 session.add(category)
                 session.flush()  # Get the ID
@@ -213,6 +217,8 @@ def import_data():
                 end_date=pp_data.end_date,
                 expected_income=pp_data.expected_income,
                 actual_income=pp_data.actual_income,
+                additional_income=pp_data.additional_income,
+                additional_income_description=pp_data.additional_income_description,
                 notes=pp_data.notes,
             )
             session.add(pay_period)

--- a/backend/app/schemas/data_management.py
+++ b/backend/app/schemas/data_management.py
@@ -12,6 +12,7 @@ class CategoryExport(BaseModel):
     name: str
     description: str | None
     color: str
+    monthly_target: Decimal | None = None
 
 
 class BillTemplateExport(BaseModel):
@@ -54,6 +55,8 @@ class PayPeriodExport(BaseModel):
     end_date: date
     expected_income: Decimal
     actual_income: Decimal | None
+    additional_income: Decimal | None = None
+    additional_income_description: str | None = None
     notes: str | None
     bills: list[PayPeriodBillExport]
     spending_entries: list[SpendingEntryExport]

--- a/backend/tests/test_data_management.py
+++ b/backend/tests/test_data_management.py
@@ -80,6 +80,34 @@ class TestDataExport:
         assert se["amount"] == "150.00"
         assert se["category_name"] == "Food"
 
+    def test_export_includes_category_monthly_target(self, client, session):
+        session.add(
+            Category(
+                name="Groceries", color="#22c55e", monthly_target=Decimal("450.00")
+            )
+        )
+        session.add(Category(name="Travel", color="#06b6d4"))  # no target
+        session.commit()
+
+        response = client.get("/api/data/export")
+        data = json.loads(response.data)
+        by_name = {c["name"]: c for c in data["data"]["categories"]}
+        assert by_name["Groceries"]["monthly_target"] == "450.00"
+        assert by_name["Travel"]["monthly_target"] is None
+
+    def test_export_includes_pay_period_additional_income(
+        self, client, session, sample_pay_period
+    ):
+        sample_pay_period.additional_income = Decimal("750.00")
+        sample_pay_period.additional_income_description = "Tax refund"
+        session.commit()
+
+        response = client.get("/api/data/export")
+        data = json.loads(response.data)
+        pp = data["data"]["pay_periods"][0]
+        assert pp["additional_income"] == "750.00"
+        assert pp["additional_income_description"] == "Tax refund"
+
     def test_export_bill_template_with_category(self, client, session, sample_category):
         """Export maps bill template category_id to category_name."""
         template = BillTemplate(
@@ -325,6 +353,111 @@ class TestDataImport:
         assert len(pay_period.spending_entries) == 1
         assert pay_period.spending_entries[0].description == "Coffee"
 
+    def test_import_sets_category_monthly_target(self, client, session):
+        import_data = {
+            "export_version": "1.0",
+            "export_date": "2026-04-27T10:00:00Z",
+            "data": {
+                "categories": [
+                    {
+                        "name": "Groceries",
+                        "description": None,
+                        "color": "#22c55e",
+                        "monthly_target": "450.00",
+                    },
+                    {
+                        "name": "Travel",
+                        "description": None,
+                        "color": "#06b6d4",
+                        "monthly_target": None,
+                    },
+                ],
+                "bill_templates": [],
+                "pay_periods": [],
+            },
+        }
+
+        response = client.post(
+            "/api/data/import",
+            data=json.dumps(import_data),
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+
+        groceries = session.query(Category).filter_by(name="Groceries").one()
+        travel = session.query(Category).filter_by(name="Travel").one()
+        assert groceries.monthly_target == Decimal("450.00")
+        assert travel.monthly_target is None
+
+    def test_import_sets_pay_period_additional_income(self, client, session):
+        import_data = {
+            "export_version": "1.0",
+            "export_date": "2026-04-27T10:00:00Z",
+            "data": {
+                "categories": [],
+                "bill_templates": [],
+                "pay_periods": [
+                    {
+                        "start_date": "2026-04-06",
+                        "end_date": "2026-04-19",
+                        "expected_income": "2500.00",
+                        "actual_income": None,
+                        "additional_income": "300.00",
+                        "additional_income_description": "Side gig",
+                        "notes": None,
+                        "bills": [],
+                        "spending_entries": [],
+                    }
+                ],
+            },
+        }
+
+        response = client.post(
+            "/api/data/import",
+            data=json.dumps(import_data),
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+
+        pp = session.query(PayPeriod).one()
+        assert pp.additional_income == Decimal("300.00")
+        assert pp.additional_income_description == "Side gig"
+
+    def test_import_omitting_new_fields_still_works(self, client, session):
+        """Old export format without monthly_target/additional_income still imports."""
+        import_data = {
+            "export_version": "1.0",
+            "export_date": "2026-04-27T10:00:00Z",
+            "data": {
+                "categories": [
+                    {"name": "Groceries", "description": None, "color": "#22c55e"}
+                ],
+                "bill_templates": [],
+                "pay_periods": [
+                    {
+                        "start_date": "2026-04-06",
+                        "end_date": "2026-04-19",
+                        "expected_income": "2500.00",
+                        "actual_income": None,
+                        "notes": None,
+                        "bills": [],
+                        "spending_entries": [],
+                    }
+                ],
+            },
+        }
+
+        response = client.post(
+            "/api/data/import",
+            data=json.dumps(import_data),
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+        cat = session.query(Category).one()
+        pp = session.query(PayPeriod).one()
+        assert cat.monthly_target is None
+        assert pp.additional_income is None
+
     def test_import_invalid_format(self, client, session):
         """Import rejects invalid data format."""
         import_data = {"invalid": "data"}
@@ -482,3 +615,38 @@ class TestExportImportRoundTrip:
         assert pay_period.expected_income == Decimal("2500.00")
         assert pay_period.bills[0].name == "Rent"
         assert pay_period.spending_entries[0].description == "Groceries at Publix"
+
+    def test_round_trip_preserves_monthly_target_and_additional_income(
+        self, client, session, sample_pay_period
+    ):
+        # Set up the new fields on existing fixtures
+        session.add(
+            Category(
+                name="Groceries", color="#22c55e", monthly_target=Decimal("450.00")
+            )
+        )
+        sample_pay_period.additional_income = Decimal("750.00")
+        sample_pay_period.additional_income_description = "Tax refund"
+        session.commit()
+
+        export_response = client.get("/api/data/export")
+        exported_data = json.loads(export_response.data)
+
+        client.delete(
+            "/api/data/reset",
+            headers={"X-Confirm-Reset": "DELETE-ALL-DATA"},
+        )
+
+        import_response = client.post(
+            "/api/data/import",
+            data=json.dumps(exported_data),
+            content_type="application/json",
+        )
+        assert import_response.status_code == 200
+
+        cat = session.query(Category).filter_by(name="Groceries").one()
+        assert cat.monthly_target == Decimal("450.00")
+
+        pp = session.query(PayPeriod).one()
+        assert pp.additional_income == Decimal("750.00")
+        assert pp.additional_income_description == "Tax refund"

--- a/seed/trending_down.json
+++ b/seed/trending_down.json
@@ -1,0 +1,239 @@
+{
+  "export_version": "1.0",
+  "export_date": "2026-04-27T00:00:00+00:00",
+  "data": {
+    "categories": [
+      {"name": "Groceries", "description": "Supermarket and food shopping", "color": "#22c55e", "monthly_target": "500.00"},
+      {"name": "Dining Out", "description": "Restaurants, cafes, takeout", "color": "#f59e0b", "monthly_target": "300.00"},
+      {"name": "Gas", "description": "Fuel for the car", "color": "#eab308", "monthly_target": "120.00"},
+      {"name": "Entertainment", "description": "Movies, games, events", "color": "#a855f7", "monthly_target": "150.00"},
+      {"name": "Shopping", "description": "Clothing, electronics, household", "color": "#ec4899", "monthly_target": "250.00"},
+      {"name": "Health", "description": "Pharmacy, gym, copays", "color": "#14b8a6", "monthly_target": "100.00"},
+      {"name": "Utilities", "description": "Internet, phone, electric", "color": "#3b82f6", "monthly_target": null},
+      {"name": "Travel", "description": "Trips, hotels, flights", "color": "#06b6d4", "monthly_target": "200.00"}
+    ],
+    "bill_templates": [
+      {"name": "Rent", "default_amount": "1500.00", "due_day_of_month": 1, "is_recurring": true, "category_name": null, "notes": null},
+      {"name": "Internet", "default_amount": "80.00", "due_day_of_month": 5, "is_recurring": true, "category_name": "Utilities", "notes": null},
+      {"name": "Phone", "default_amount": "60.00", "due_day_of_month": 12, "is_recurring": true, "category_name": "Utilities", "notes": null},
+      {"name": "Electric", "default_amount": "90.00", "due_day_of_month": 15, "is_recurring": true, "category_name": "Utilities", "notes": null},
+      {"name": "Streaming", "default_amount": "35.00", "due_day_of_month": 18, "is_recurring": true, "category_name": "Entertainment", "notes": null}
+    ],
+    "pay_periods": [
+      {
+        "start_date": "2025-11-06",
+        "end_date": "2025-11-19",
+        "expected_income": "2500.00",
+        "actual_income": "2500.00",
+        "notes": null,
+        "bills": [
+          {"name": "Phone", "amount": "60.00", "due_date": "2025-11-12", "is_paid": true, "paid_date": "2025-11-12", "notes": null, "bill_template_name": "Phone"},
+          {"name": "Electric", "amount": "90.00", "due_date": "2025-11-15", "is_paid": true, "paid_date": "2025-11-15", "notes": null, "bill_template_name": "Electric"},
+          {"name": "Streaming", "amount": "35.00", "due_date": "2025-11-18", "is_paid": true, "paid_date": "2025-11-18", "notes": null, "bill_template_name": "Streaming"}
+        ],
+        "spending_entries": [
+          {"description": "Costco haul", "amount": "250.00", "spent_date": "2025-11-08", "category_name": "Groceries", "notes": null},
+          {"description": "Date night", "amount": "200.00", "spent_date": "2025-11-11", "category_name": "Dining Out", "notes": null},
+          {"description": "Hotel night", "amount": "300.00", "spent_date": "2025-11-14", "category_name": "Travel", "notes": null},
+          {"description": "Headphones", "amount": "250.00", "spent_date": "2025-11-17", "category_name": "Shopping", "notes": null}
+        ]
+      },
+      {
+        "start_date": "2025-11-20",
+        "end_date": "2025-12-05",
+        "expected_income": "2500.00",
+        "actual_income": "2500.00",
+        "notes": null,
+        "bills": [
+          {"name": "Rent", "amount": "1500.00", "due_date": "2025-12-01", "is_paid": true, "paid_date": "2025-12-01", "notes": null, "bill_template_name": "Rent"},
+          {"name": "Internet", "amount": "80.00", "due_date": "2025-12-05", "is_paid": true, "paid_date": "2025-12-05", "notes": null, "bill_template_name": "Internet"}
+        ],
+        "spending_entries": [
+          {"description": "Whole Foods run", "amount": "245.00", "spent_date": "2025-11-22", "category_name": "Groceries", "notes": null},
+          {"description": "Brunch", "amount": "180.00", "spent_date": "2025-11-26", "category_name": "Dining Out", "notes": null},
+          {"description": "Amazon order", "amount": "295.00", "spent_date": "2025-11-30", "category_name": "Shopping", "notes": null},
+          {"description": "Concert ticket", "amount": "180.00", "spent_date": "2025-12-03", "category_name": "Entertainment", "notes": null}
+        ]
+      },
+      {
+        "start_date": "2025-12-06",
+        "end_date": "2025-12-19",
+        "expected_income": "2500.00",
+        "actual_income": "2500.00",
+        "notes": null,
+        "bills": [
+          {"name": "Phone", "amount": "60.00", "due_date": "2025-12-12", "is_paid": true, "paid_date": "2025-12-12", "notes": null, "bill_template_name": "Phone"},
+          {"name": "Electric", "amount": "90.00", "due_date": "2025-12-15", "is_paid": true, "paid_date": "2025-12-15", "notes": null, "bill_template_name": "Electric"},
+          {"name": "Streaming", "amount": "35.00", "due_date": "2025-12-18", "is_paid": true, "paid_date": "2025-12-18", "notes": null, "bill_template_name": "Streaming"}
+        ],
+        "spending_entries": [
+          {"description": "Trader Joe's", "amount": "230.00", "spent_date": "2025-12-08", "category_name": "Groceries", "notes": null},
+          {"description": "Lunch w/ team", "amount": "175.00", "spent_date": "2025-12-12", "category_name": "Dining Out", "notes": null},
+          {"description": "Flight booking", "amount": "250.00", "spent_date": "2025-12-15", "category_name": "Travel", "notes": null},
+          {"description": "Kitchen gadget", "amount": "195.00", "spent_date": "2025-12-18", "category_name": "Shopping", "notes": null}
+        ]
+      },
+      {
+        "start_date": "2025-12-20",
+        "end_date": "2026-01-05",
+        "expected_income": "2500.00",
+        "actual_income": "2500.00",
+        "additional_income": "750.00",
+        "additional_income_description": "Year-end bonus",
+        "notes": null,
+        "bills": [
+          {"name": "Rent", "amount": "1500.00", "due_date": "2026-01-01", "is_paid": true, "paid_date": "2026-01-01", "notes": null, "bill_template_name": "Rent"},
+          {"name": "Internet", "amount": "80.00", "due_date": "2026-01-05", "is_paid": true, "paid_date": "2026-01-05", "notes": null, "bill_template_name": "Internet"}
+        ],
+        "spending_entries": [
+          {"description": "Costco haul", "amount": "225.00", "spent_date": "2025-12-22", "category_name": "Groceries", "notes": null},
+          {"description": "Date night", "amount": "185.00", "spent_date": "2025-12-26", "category_name": "Dining Out", "notes": null},
+          {"description": "New shoes", "amount": "215.00", "spent_date": "2025-12-30", "category_name": "Shopping", "notes": null},
+          {"description": "Steam game", "amount": "175.00", "spent_date": "2026-01-02", "category_name": "Entertainment", "notes": null}
+        ]
+      },
+      {
+        "start_date": "2026-01-06",
+        "end_date": "2026-01-19",
+        "expected_income": "2500.00",
+        "actual_income": "2500.00",
+        "notes": null,
+        "bills": [
+          {"name": "Phone", "amount": "60.00", "due_date": "2026-01-12", "is_paid": true, "paid_date": "2026-01-12", "notes": null, "bill_template_name": "Phone"},
+          {"name": "Electric", "amount": "90.00", "due_date": "2026-01-15", "is_paid": true, "paid_date": "2026-01-15", "notes": null, "bill_template_name": "Electric"},
+          {"name": "Streaming", "amount": "35.00", "due_date": "2026-01-18", "is_paid": true, "paid_date": "2026-01-18", "notes": null, "bill_template_name": "Streaming"}
+        ],
+        "spending_entries": [
+          {"description": "Whole Foods run", "amount": "215.00", "spent_date": "2026-01-08", "category_name": "Groceries", "notes": null},
+          {"description": "Shell fillup", "amount": "55.00", "spent_date": "2026-01-11", "category_name": "Gas", "notes": null},
+          {"description": "Friday pizza", "amount": "145.00", "spent_date": "2026-01-13", "category_name": "Dining Out", "notes": null},
+          {"description": "Amazon order", "amount": "335.00", "spent_date": "2026-01-17", "category_name": "Shopping", "notes": null}
+        ]
+      },
+      {
+        "start_date": "2026-01-20",
+        "end_date": "2026-02-05",
+        "expected_income": "2500.00",
+        "actual_income": "2500.00",
+        "notes": null,
+        "bills": [
+          {"name": "Rent", "amount": "1500.00", "due_date": "2026-02-01", "is_paid": true, "paid_date": "2026-02-01", "notes": null, "bill_template_name": "Rent"},
+          {"name": "Internet", "amount": "80.00", "due_date": "2026-02-05", "is_paid": true, "paid_date": "2026-02-05", "notes": null, "bill_template_name": "Internet"}
+        ],
+        "spending_entries": [
+          {"description": "Trader Joe's", "amount": "200.00", "spent_date": "2026-01-22", "category_name": "Groceries", "notes": null},
+          {"description": "Brunch", "amount": "130.00", "spent_date": "2026-01-26", "category_name": "Dining Out", "notes": null},
+          {"description": "Gym membership", "amount": "60.00", "spent_date": "2026-01-30", "category_name": "Health", "notes": null},
+          {"description": "Hotel night", "amount": "310.00", "spent_date": "2026-02-02", "category_name": "Travel", "notes": null}
+        ]
+      },
+      {
+        "start_date": "2026-02-06",
+        "end_date": "2026-02-19",
+        "expected_income": "2500.00",
+        "actual_income": "2500.00",
+        "notes": null,
+        "bills": [
+          {"name": "Phone", "amount": "60.00", "due_date": "2026-02-12", "is_paid": true, "paid_date": "2026-02-12", "notes": null, "bill_template_name": "Phone"},
+          {"name": "Electric", "amount": "90.00", "due_date": "2026-02-15", "is_paid": true, "paid_date": "2026-02-15", "notes": null, "bill_template_name": "Electric"},
+          {"name": "Streaming", "amount": "35.00", "due_date": "2026-02-18", "is_paid": true, "paid_date": "2026-02-18", "notes": null, "bill_template_name": "Streaming"}
+        ],
+        "spending_entries": [
+          {"description": "Whole Foods run", "amount": "190.00", "spent_date": "2026-02-08", "category_name": "Groceries", "notes": null},
+          {"description": "Date night", "amount": "125.00", "spent_date": "2026-02-12", "category_name": "Dining Out", "notes": null},
+          {"description": "Board game cafe", "amount": "75.00", "spent_date": "2026-02-15", "category_name": "Entertainment", "notes": null},
+          {"description": "Headphones", "amount": "260.00", "spent_date": "2026-02-18", "category_name": "Shopping", "notes": null}
+        ]
+      },
+      {
+        "start_date": "2026-02-20",
+        "end_date": "2026-03-05",
+        "expected_income": "2500.00",
+        "actual_income": "2500.00",
+        "notes": null,
+        "bills": [
+          {"name": "Rent", "amount": "1500.00", "due_date": "2026-03-01", "is_paid": true, "paid_date": "2026-03-01", "notes": null, "bill_template_name": "Rent"},
+          {"name": "Internet", "amount": "80.00", "due_date": "2026-03-05", "is_paid": true, "paid_date": "2026-03-05", "notes": null, "bill_template_name": "Internet"}
+        ],
+        "spending_entries": [
+          {"description": "Costco haul", "amount": "180.00", "spent_date": "2026-02-22", "category_name": "Groceries", "notes": null},
+          {"description": "Takeout", "amount": "115.00", "spent_date": "2026-02-26", "category_name": "Dining Out", "notes": null},
+          {"description": "Costco gas", "amount": "50.00", "spent_date": "2026-03-01", "category_name": "Gas", "notes": null},
+          {"description": "Amazon order", "amount": "255.00", "spent_date": "2026-03-04", "category_name": "Shopping", "notes": null}
+        ]
+      },
+      {
+        "start_date": "2026-03-06",
+        "end_date": "2026-03-19",
+        "expected_income": "2500.00",
+        "actual_income": "2500.00",
+        "notes": null,
+        "bills": [
+          {"name": "Phone", "amount": "60.00", "due_date": "2026-03-12", "is_paid": true, "paid_date": "2026-03-12", "notes": null, "bill_template_name": "Phone"},
+          {"name": "Electric", "amount": "90.00", "due_date": "2026-03-15", "is_paid": true, "paid_date": "2026-03-15", "notes": null, "bill_template_name": "Electric"},
+          {"name": "Streaming", "amount": "35.00", "due_date": "2026-03-18", "is_paid": true, "paid_date": "2026-03-18", "notes": null, "bill_template_name": "Streaming"}
+        ],
+        "spending_entries": [
+          {"description": "Whole Foods run", "amount": "170.00", "spent_date": "2026-03-08", "category_name": "Groceries", "notes": null},
+          {"description": "Lunch w/ team", "amount": "105.00", "spent_date": "2026-03-12", "category_name": "Dining Out", "notes": null},
+          {"description": "Movie night", "amount": "50.00", "spent_date": "2026-03-15", "category_name": "Entertainment", "notes": null},
+          {"description": "New shoes", "amount": "225.00", "spent_date": "2026-03-18", "category_name": "Shopping", "notes": null}
+        ]
+      },
+      {
+        "start_date": "2026-03-20",
+        "end_date": "2026-04-05",
+        "expected_income": "2500.00",
+        "actual_income": "2500.00",
+        "additional_income": "1500.00",
+        "additional_income_description": "Tax refund",
+        "notes": null,
+        "bills": [
+          {"name": "Rent", "amount": "1500.00", "due_date": "2026-04-01", "is_paid": true, "paid_date": "2026-04-01", "notes": null, "bill_template_name": "Rent"},
+          {"name": "Internet", "amount": "80.00", "due_date": "2026-04-05", "is_paid": true, "paid_date": "2026-04-05", "notes": null, "bill_template_name": "Internet"}
+        ],
+        "spending_entries": [
+          {"description": "Trader Joe's", "amount": "160.00", "spent_date": "2026-03-22", "category_name": "Groceries", "notes": null},
+          {"description": "Date night", "amount": "95.00", "spent_date": "2026-03-26", "category_name": "Dining Out", "notes": null},
+          {"description": "Pharmacy", "amount": "35.00", "spent_date": "2026-03-30", "category_name": "Health", "notes": null},
+          {"description": "Target run", "amount": "210.00", "spent_date": "2026-04-02", "category_name": "Shopping", "notes": null}
+        ]
+      },
+      {
+        "start_date": "2026-04-06",
+        "end_date": "2026-04-19",
+        "expected_income": "2500.00",
+        "actual_income": "2500.00",
+        "notes": null,
+        "bills": [
+          {"name": "Phone", "amount": "60.00", "due_date": "2026-04-12", "is_paid": true, "paid_date": "2026-04-12", "notes": null, "bill_template_name": "Phone"},
+          {"name": "Electric", "amount": "90.00", "due_date": "2026-04-15", "is_paid": true, "paid_date": "2026-04-15", "notes": null, "bill_template_name": "Electric"},
+          {"name": "Streaming", "amount": "35.00", "due_date": "2026-04-18", "is_paid": true, "paid_date": "2026-04-18", "notes": null, "bill_template_name": "Streaming"}
+        ],
+        "spending_entries": [
+          {"description": "Costco haul", "amount": "155.00", "spent_date": "2026-04-08", "category_name": "Groceries", "notes": null},
+          {"description": "Brunch", "amount": "80.00", "spent_date": "2026-04-12", "category_name": "Dining Out", "notes": null},
+          {"description": "Spotify family", "amount": "20.00", "spent_date": "2026-04-15", "category_name": "Entertainment", "notes": null},
+          {"description": "Amazon order", "amount": "195.00", "spent_date": "2026-04-18", "category_name": "Shopping", "notes": null}
+        ]
+      },
+      {
+        "start_date": "2026-04-20",
+        "end_date": "2026-05-05",
+        "expected_income": "2500.00",
+        "actual_income": null,
+        "notes": null,
+        "bills": [
+          {"name": "Rent", "amount": "1500.00", "due_date": "2026-05-01", "is_paid": false, "paid_date": null, "notes": null, "bill_template_name": "Rent"},
+          {"name": "Internet", "amount": "80.00", "due_date": "2026-05-05", "is_paid": false, "paid_date": null, "notes": null, "bill_template_name": "Internet"}
+        ],
+        "spending_entries": [
+          {"description": "Whole Foods run", "amount": "145.00", "spent_date": "2026-04-22", "category_name": "Groceries", "notes": null},
+          {"description": "Date night", "amount": "85.00", "spent_date": "2026-04-26", "category_name": "Dining Out", "notes": null},
+          {"description": "Shell fillup", "amount": "50.00", "spent_date": "2026-04-30", "category_name": "Gas", "notes": null},
+          {"description": "Target run", "amount": "120.00", "spent_date": "2026-05-03", "category_name": "Shopping", "notes": null}
+        ]
+      }
+    ]
+  }
+}

--- a/seed/trending_up.json
+++ b/seed/trending_up.json
@@ -1,0 +1,239 @@
+{
+  "export_version": "1.0",
+  "export_date": "2026-04-27T00:00:00+00:00",
+  "data": {
+    "categories": [
+      {"name": "Groceries", "description": "Supermarket and food shopping", "color": "#22c55e", "monthly_target": "500.00"},
+      {"name": "Dining Out", "description": "Restaurants, cafes, takeout", "color": "#f59e0b", "monthly_target": "300.00"},
+      {"name": "Gas", "description": "Fuel for the car", "color": "#eab308", "monthly_target": "120.00"},
+      {"name": "Entertainment", "description": "Movies, games, events", "color": "#a855f7", "monthly_target": "150.00"},
+      {"name": "Shopping", "description": "Clothing, electronics, household", "color": "#ec4899", "monthly_target": "250.00"},
+      {"name": "Health", "description": "Pharmacy, gym, copays", "color": "#14b8a6", "monthly_target": "100.00"},
+      {"name": "Utilities", "description": "Internet, phone, electric", "color": "#3b82f6", "monthly_target": null},
+      {"name": "Travel", "description": "Trips, hotels, flights", "color": "#06b6d4", "monthly_target": "200.00"}
+    ],
+    "bill_templates": [
+      {"name": "Rent", "default_amount": "1500.00", "due_day_of_month": 1, "is_recurring": true, "category_name": null, "notes": null},
+      {"name": "Internet", "default_amount": "80.00", "due_day_of_month": 5, "is_recurring": true, "category_name": "Utilities", "notes": null},
+      {"name": "Phone", "default_amount": "60.00", "due_day_of_month": 12, "is_recurring": true, "category_name": "Utilities", "notes": null},
+      {"name": "Electric", "default_amount": "90.00", "due_day_of_month": 15, "is_recurring": true, "category_name": "Utilities", "notes": null},
+      {"name": "Streaming", "default_amount": "35.00", "due_day_of_month": 18, "is_recurring": true, "category_name": "Entertainment", "notes": null}
+    ],
+    "pay_periods": [
+      {
+        "start_date": "2025-11-06",
+        "end_date": "2025-11-19",
+        "expected_income": "2500.00",
+        "actual_income": "2500.00",
+        "notes": null,
+        "bills": [
+          {"name": "Phone", "amount": "60.00", "due_date": "2025-11-12", "is_paid": true, "paid_date": "2025-11-12", "notes": null, "bill_template_name": "Phone"},
+          {"name": "Electric", "amount": "90.00", "due_date": "2025-11-15", "is_paid": true, "paid_date": "2025-11-15", "notes": null, "bill_template_name": "Electric"},
+          {"name": "Streaming", "amount": "35.00", "due_date": "2025-11-18", "is_paid": true, "paid_date": "2025-11-18", "notes": null, "bill_template_name": "Streaming"}
+        ],
+        "spending_entries": [
+          {"description": "Whole Foods run", "amount": "145.00", "spent_date": "2025-11-08", "category_name": "Groceries", "notes": null},
+          {"description": "Shell fillup", "amount": "50.00", "spent_date": "2025-11-11", "category_name": "Gas", "notes": null},
+          {"description": "Date night", "amount": "85.00", "spent_date": "2025-11-14", "category_name": "Dining Out", "notes": null},
+          {"description": "Target run", "amount": "120.00", "spent_date": "2025-11-17", "category_name": "Shopping", "notes": null}
+        ]
+      },
+      {
+        "start_date": "2025-11-20",
+        "end_date": "2025-12-05",
+        "expected_income": "2500.00",
+        "actual_income": "2500.00",
+        "notes": null,
+        "bills": [
+          {"name": "Rent", "amount": "1500.00", "due_date": "2025-12-01", "is_paid": true, "paid_date": "2025-12-01", "notes": null, "bill_template_name": "Rent"},
+          {"name": "Internet", "amount": "80.00", "due_date": "2025-12-05", "is_paid": true, "paid_date": "2025-12-05", "notes": null, "bill_template_name": "Internet"}
+        ],
+        "spending_entries": [
+          {"description": "Costco haul", "amount": "170.00", "spent_date": "2025-11-22", "category_name": "Groceries", "notes": null},
+          {"description": "Brunch", "amount": "80.00", "spent_date": "2025-11-26", "category_name": "Dining Out", "notes": null},
+          {"description": "Costco gas", "amount": "50.00", "spent_date": "2025-11-30", "category_name": "Gas", "notes": null},
+          {"description": "Amazon order", "amount": "150.00", "spent_date": "2025-12-03", "category_name": "Shopping", "notes": null}
+        ]
+      },
+      {
+        "start_date": "2025-12-06",
+        "end_date": "2025-12-19",
+        "expected_income": "2500.00",
+        "actual_income": "2500.00",
+        "notes": null,
+        "bills": [
+          {"name": "Phone", "amount": "60.00", "due_date": "2025-12-12", "is_paid": true, "paid_date": "2025-12-12", "notes": null, "bill_template_name": "Phone"},
+          {"name": "Electric", "amount": "90.00", "due_date": "2025-12-15", "is_paid": true, "paid_date": "2025-12-15", "notes": null, "bill_template_name": "Electric"},
+          {"name": "Streaming", "amount": "35.00", "due_date": "2025-12-18", "is_paid": true, "paid_date": "2025-12-18", "notes": null, "bill_template_name": "Streaming"}
+        ],
+        "spending_entries": [
+          {"description": "Trader Joe's", "amount": "135.00", "spent_date": "2025-12-08", "category_name": "Groceries", "notes": null},
+          {"description": "Lunch w/ team", "amount": "75.00", "spent_date": "2025-12-12", "category_name": "Dining Out", "notes": null},
+          {"description": "Concert ticket", "amount": "90.00", "spent_date": "2025-12-15", "category_name": "Entertainment", "notes": null},
+          {"description": "Headphones", "amount": "200.00", "spent_date": "2025-12-18", "category_name": "Shopping", "notes": null}
+        ]
+      },
+      {
+        "start_date": "2025-12-20",
+        "end_date": "2026-01-05",
+        "expected_income": "2500.00",
+        "actual_income": "2500.00",
+        "additional_income": "500.00",
+        "additional_income_description": "Holiday bonus",
+        "notes": null,
+        "bills": [
+          {"name": "Rent", "amount": "1500.00", "due_date": "2026-01-01", "is_paid": true, "paid_date": "2026-01-01", "notes": null, "bill_template_name": "Rent"},
+          {"name": "Internet", "amount": "80.00", "due_date": "2026-01-05", "is_paid": true, "paid_date": "2026-01-05", "notes": null, "bill_template_name": "Internet"}
+        ],
+        "spending_entries": [
+          {"description": "Whole Foods run", "amount": "180.00", "spent_date": "2025-12-22", "category_name": "Groceries", "notes": null},
+          {"description": "Date night", "amount": "110.00", "spent_date": "2025-12-26", "category_name": "Dining Out", "notes": null},
+          {"description": "Kitchen gadget", "amount": "145.00", "spent_date": "2025-12-30", "category_name": "Shopping", "notes": null},
+          {"description": "Steam game", "amount": "115.00", "spent_date": "2026-01-02", "category_name": "Entertainment", "notes": null}
+        ]
+      },
+      {
+        "start_date": "2026-01-06",
+        "end_date": "2026-01-19",
+        "expected_income": "2500.00",
+        "actual_income": "2500.00",
+        "notes": null,
+        "bills": [
+          {"name": "Phone", "amount": "60.00", "due_date": "2026-01-12", "is_paid": true, "paid_date": "2026-01-12", "notes": null, "bill_template_name": "Phone"},
+          {"name": "Electric", "amount": "90.00", "due_date": "2026-01-15", "is_paid": true, "paid_date": "2026-01-15", "notes": null, "bill_template_name": "Electric"},
+          {"name": "Streaming", "amount": "35.00", "due_date": "2026-01-18", "is_paid": true, "paid_date": "2026-01-18", "notes": null, "bill_template_name": "Streaming"}
+        ],
+        "spending_entries": [
+          {"description": "Costco haul", "amount": "190.00", "spent_date": "2026-01-08", "category_name": "Groceries", "notes": null},
+          {"description": "Shell fillup", "amount": "55.00", "spent_date": "2026-01-11", "category_name": "Gas", "notes": null},
+          {"description": "Friday pizza", "amount": "140.00", "spent_date": "2026-01-13", "category_name": "Dining Out", "notes": null},
+          {"description": "New shoes", "amount": "215.00", "spent_date": "2026-01-17", "category_name": "Shopping", "notes": null}
+        ]
+      },
+      {
+        "start_date": "2026-01-20",
+        "end_date": "2026-02-05",
+        "expected_income": "2500.00",
+        "actual_income": "2500.00",
+        "notes": null,
+        "bills": [
+          {"name": "Rent", "amount": "1500.00", "due_date": "2026-02-01", "is_paid": true, "paid_date": "2026-02-01", "notes": null, "bill_template_name": "Rent"},
+          {"name": "Internet", "amount": "80.00", "due_date": "2026-02-05", "is_paid": true, "paid_date": "2026-02-05", "notes": null, "bill_template_name": "Internet"}
+        ],
+        "spending_entries": [
+          {"description": "Trader Joe's", "amount": "200.00", "spent_date": "2026-01-22", "category_name": "Groceries", "notes": null},
+          {"description": "Brunch", "amount": "135.00", "spent_date": "2026-01-26", "category_name": "Dining Out", "notes": null},
+          {"description": "Gym membership", "amount": "60.00", "spent_date": "2026-01-30", "category_name": "Health", "notes": null},
+          {"description": "Hotel night", "amount": "255.00", "spent_date": "2026-02-02", "category_name": "Travel", "notes": null}
+        ]
+      },
+      {
+        "start_date": "2026-02-06",
+        "end_date": "2026-02-19",
+        "expected_income": "2500.00",
+        "actual_income": "2500.00",
+        "notes": null,
+        "bills": [
+          {"name": "Phone", "amount": "60.00", "due_date": "2026-02-12", "is_paid": true, "paid_date": "2026-02-12", "notes": null, "bill_template_name": "Phone"},
+          {"name": "Electric", "amount": "90.00", "due_date": "2026-02-15", "is_paid": true, "paid_date": "2026-02-15", "notes": null, "bill_template_name": "Electric"},
+          {"name": "Streaming", "amount": "35.00", "due_date": "2026-02-18", "is_paid": true, "paid_date": "2026-02-18", "notes": null, "bill_template_name": "Streaming"}
+        ],
+        "spending_entries": [
+          {"description": "Whole Foods run", "amount": "215.00", "spent_date": "2026-02-08", "category_name": "Groceries", "notes": null},
+          {"description": "Date night", "amount": "145.00", "spent_date": "2026-02-12", "category_name": "Dining Out", "notes": null},
+          {"description": "Board game cafe", "amount": "80.00", "spent_date": "2026-02-15", "category_name": "Entertainment", "notes": null},
+          {"description": "Amazon order", "amount": "260.00", "spent_date": "2026-02-18", "category_name": "Shopping", "notes": null}
+        ]
+      },
+      {
+        "start_date": "2026-02-20",
+        "end_date": "2026-03-05",
+        "expected_income": "2500.00",
+        "actual_income": "2500.00",
+        "notes": null,
+        "bills": [
+          {"name": "Rent", "amount": "1500.00", "due_date": "2026-03-01", "is_paid": true, "paid_date": "2026-03-01", "notes": null, "bill_template_name": "Rent"},
+          {"name": "Internet", "amount": "80.00", "due_date": "2026-03-05", "is_paid": true, "paid_date": "2026-03-05", "notes": null, "bill_template_name": "Internet"}
+        ],
+        "spending_entries": [
+          {"description": "Costco haul", "amount": "225.00", "spent_date": "2026-02-22", "category_name": "Groceries", "notes": null},
+          {"description": "Takeout", "amount": "165.00", "spent_date": "2026-02-26", "category_name": "Dining Out", "notes": null},
+          {"description": "Costco gas", "amount": "60.00", "spent_date": "2026-03-01", "category_name": "Gas", "notes": null},
+          {"description": "Flight booking", "amount": "300.00", "spent_date": "2026-03-04", "category_name": "Travel", "notes": null}
+        ]
+      },
+      {
+        "start_date": "2026-03-06",
+        "end_date": "2026-03-19",
+        "expected_income": "2500.00",
+        "actual_income": "2500.00",
+        "notes": null,
+        "bills": [
+          {"name": "Phone", "amount": "60.00", "due_date": "2026-03-12", "is_paid": true, "paid_date": "2026-03-12", "notes": null, "bill_template_name": "Phone"},
+          {"name": "Electric", "amount": "90.00", "due_date": "2026-03-15", "is_paid": true, "paid_date": "2026-03-15", "notes": null, "bill_template_name": "Electric"},
+          {"name": "Streaming", "amount": "35.00", "due_date": "2026-03-18", "is_paid": true, "paid_date": "2026-03-18", "notes": null, "bill_template_name": "Streaming"}
+        ],
+        "spending_entries": [
+          {"description": "Whole Foods run", "amount": "235.00", "spent_date": "2026-03-08", "category_name": "Groceries", "notes": null},
+          {"description": "Lunch w/ team", "amount": "175.00", "spent_date": "2026-03-12", "category_name": "Dining Out", "notes": null},
+          {"description": "Concert ticket", "amount": "120.00", "spent_date": "2026-03-15", "category_name": "Entertainment", "notes": null},
+          {"description": "New shoes", "amount": "270.00", "spent_date": "2026-03-18", "category_name": "Shopping", "notes": null}
+        ]
+      },
+      {
+        "start_date": "2026-03-20",
+        "end_date": "2026-04-05",
+        "expected_income": "2500.00",
+        "actual_income": "2500.00",
+        "additional_income": "1200.00",
+        "additional_income_description": "Tax refund",
+        "notes": null,
+        "bills": [
+          {"name": "Rent", "amount": "1500.00", "due_date": "2026-04-01", "is_paid": true, "paid_date": "2026-04-01", "notes": null, "bill_template_name": "Rent"},
+          {"name": "Internet", "amount": "80.00", "due_date": "2026-04-05", "is_paid": true, "paid_date": "2026-04-05", "notes": null, "bill_template_name": "Internet"}
+        ],
+        "spending_entries": [
+          {"description": "Trader Joe's", "amount": "250.00", "spent_date": "2026-03-22", "category_name": "Groceries", "notes": null},
+          {"description": "Date night", "amount": "185.00", "spent_date": "2026-03-26", "category_name": "Dining Out", "notes": null},
+          {"description": "Headphones", "amount": "220.00", "spent_date": "2026-03-30", "category_name": "Shopping", "notes": null},
+          {"description": "Hotel night", "amount": "195.00", "spent_date": "2026-04-02", "category_name": "Travel", "notes": null}
+        ]
+      },
+      {
+        "start_date": "2026-04-06",
+        "end_date": "2026-04-19",
+        "expected_income": "2500.00",
+        "actual_income": "2500.00",
+        "notes": null,
+        "bills": [
+          {"name": "Phone", "amount": "60.00", "due_date": "2026-04-12", "is_paid": true, "paid_date": "2026-04-12", "notes": null, "bill_template_name": "Phone"},
+          {"name": "Electric", "amount": "90.00", "due_date": "2026-04-15", "is_paid": true, "paid_date": "2026-04-15", "notes": null, "bill_template_name": "Electric"},
+          {"name": "Streaming", "amount": "35.00", "due_date": "2026-04-18", "is_paid": true, "paid_date": "2026-04-18", "notes": null, "bill_template_name": "Streaming"}
+        ],
+        "spending_entries": [
+          {"description": "Costco haul", "amount": "260.00", "spent_date": "2026-04-08", "category_name": "Groceries", "notes": null},
+          {"description": "Brunch", "amount": "200.00", "spent_date": "2026-04-12", "category_name": "Dining Out", "notes": null},
+          {"description": "Movie night", "amount": "80.00", "spent_date": "2026-04-15", "category_name": "Entertainment", "notes": null},
+          {"description": "Amazon order", "amount": "360.00", "spent_date": "2026-04-18", "category_name": "Shopping", "notes": null}
+        ]
+      },
+      {
+        "start_date": "2026-04-20",
+        "end_date": "2026-05-05",
+        "expected_income": "2500.00",
+        "actual_income": null,
+        "notes": null,
+        "bills": [
+          {"name": "Rent", "amount": "1500.00", "due_date": "2026-05-01", "is_paid": false, "paid_date": null, "notes": null, "bill_template_name": "Rent"},
+          {"name": "Internet", "amount": "80.00", "due_date": "2026-05-05", "is_paid": false, "paid_date": null, "notes": null, "bill_template_name": "Internet"}
+        ],
+        "spending_entries": [
+          {"description": "Whole Foods run", "amount": "275.00", "spent_date": "2026-04-22", "category_name": "Groceries", "notes": null},
+          {"description": "Date night", "amount": "220.00", "spent_date": "2026-04-26", "category_name": "Dining Out", "notes": null},
+          {"description": "Flight booking", "amount": "400.00", "spent_date": "2026-04-30", "category_name": "Travel", "notes": null},
+          {"description": "Kitchen gadget", "amount": "105.00", "spent_date": "2026-05-03", "category_name": "Shopping", "notes": null}
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
Closes the two schema gaps surfaced when authoring the seed JSON. The model has these fields and the UI uses them, but the data-management export silently dropped them — so a round-trip lost user-set targets and bonus income.

### Backend
- `CategoryExport` gains `monthly_target: Decimal | None` — read in the export route, written in the import route.
- `PayPeriodExport` gains `additional_income: Decimal | None` and `additional_income_description: str | None` — same plumbing.
- Both fields default to `None` on the schema, so older export files without them still import cleanly.
- New round-trip test confirms the new fields survive export → reset → import.

### Seed data
- `seed/trending_up.json` and `seed/trending_down.json` now set `monthly_target` on 7 of 8 categories (Utilities left null since bills cover it). The budget overlay on the Category Trend chart and the donut tooltip will both light up immediately on import.
- Each file has two pay periods with `additional_income` populated (a holiday/year-end bonus in Dec, a tax refund in late March) so the additional-income card has data to render.

## Test plan
- [x] Backend: `pytest tests/` — **169 passed** (+6 new: 2 export, 3 import, 1 round-trip)
- [x] Backend lint: `ruff check .` + `ruff format --check .` — clean
- [x] JSON syntax: both seed files parse cleanly
- [ ] Manual smoke: Settings → Reset, then Settings → Import `seed/trending_up.json`. Confirm:
    - Category Management shows monthly_target column populated
    - Two pay periods (late Dec + late Mar) show "Holiday bonus" / "Tax refund" in the additional income card
    - Insights → Category Trend chart shows dashed reference lines
    - Insights → Spending by Category tooltip shows budget ratio

🤖 Generated with [Claude Code](https://claude.com/claude-code)