### PR TITLE
chore: split dependabot tooling group into focused subgroups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: weekly
       day: monday
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 8
     groups:
       tanstack:
         patterns:
@@ -17,14 +17,23 @@ updates:
           - "react-router-dom"
           - "@types/react"
           - "@types/react-dom"
-      tooling:
+      eslint:
         patterns:
-          - "eslint*"
+          - "eslint"
+          - "eslint-*"
           - "@eslint/*"
-          - "typescript*"
+          - "typescript-eslint"
+          - "globals"
+      typescript:
+        patterns:
+          - "typescript"
+      vite:
+        patterns:
           - "vite"
-          - "vitest"
           - "@vitejs/*"
+      vitest:
+        patterns:
+          - "vitest"
           - "@vitest/*"
           - "@testing-library/*"
           - "jsdom"


### PR DESCRIPTION
## Summary

Replaces the single `tooling` umbrella group with four focused subgroups (`eslint`, `typescript`, `vite`, `vitest`) so a breaking change in one toolchain stops blocking updates to the others.

## Why now

PR #38 bundled 11 dev-tool deps in one batch, including Vitest 4 (which narrowed the `Mock` type and broke 8 `InsightsToolbar.test.tsx` casts) and ESLint 10 (which tightened rules to a lint failure). Every other update in that batch -- including harmless patch-bumps like `typescript-eslint 8.59.0 -> 8.59.3` -- is unlandable until those two are fixed, so we get zero of 11.

## What changed

- **`eslint`** — `eslint`, `eslint-*`, `@eslint/*`, `typescript-eslint`, `globals`
- **`typescript`** — `typescript`
- **`vite`** — `vite`, `@vitejs/*`
- **`vitest`** — `vitest`, `@vitest/*`, `@testing-library/*`, `jsdom`

Bumped `open-pull-requests-limit` from 5 → 8 so the extra groups don't crowd out other ecosystem updates (pip, github-actions).

## Follow-up

- Close #38 after this merges (will reference this PR in the close comment)
- On the next Monday cron tick (or via `@dependabot recreate`/manual Insights trigger), Dependabot will reopen the still-pending updates as ~4 smaller PRs against this new grouping

## Test plan
- [x] YAML validates locally
- [ ] CI green on this PR
- [ ] After merge, observe next Dependabot run produces smaller, focused PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)