### PR TITLE
chore: add 7-day cooldown to Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
       interval: weekly
       day: monday
     open-pull-requests-limit: 8
+    cooldown:
+      default-days: 7
     groups:
       tanstack:
         patterns:
@@ -54,6 +56,8 @@ updates:
       interval: weekly
       day: monday
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
     labels:
       - dependencies
       - backend
@@ -64,6 +68,8 @@ updates:
       interval: weekly
       day: monday
     open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
     labels:
       - dependencies
       - ci


### PR DESCRIPTION
## Summary

Adds a 7-day cooldown to every Dependabot ecosystem (npm / pip / github-actions). Dependabot will wait 7 days after a release is published before opening a PR to bump to that version.

## Why

Most supply-chain compromises in the npm and PyPI ecosystems (Shai-Hulud, mini-Shai-Hulud, tj-actions/changed-files, etc.) are detected, deprecated, and yanked within hours-to-days of disclosure. Adding a 7-day cooldown means the broader ecosystem catches and tears down compromised versions before they ever land in our PR queue.

This complements the install-time audits already in CI:
- **Install-time filter:** \`npm audit --audit-level=high\` and \`pip-audit\` (catch known-bad versions at install)
- **PR-time filter (new):** Dependabot cooldown (don't *propose* the bump until the version is at least 7 days old)

## What this doesn't slow down

**Security updates bypass cooldown by design.** When GitHub publishes a Dependabot alert for a CVE in our dependency tree, the bump is opened immediately regardless of release age. So a legitimately-needed CVE fix still flows through as fast as it always did.

## Config diff

\`\`\`yaml
cooldown:
  default-days: 7
\`\`\`

Added to each of the three \`updates:\` entries in \`.github/dependabot.yml\`.

## Test plan
- [x] YAML validates
- [ ] CI green on this PR
- [ ] After merge, observe that next Monday's Dependabot tick produces PRs only for releases ≥7 days old

🤖 Generated with [Claude Code](https://claude.com/claude-code)