### PR TITLE
chore: sync backend/uv.lock to current pyproject version

### DIFF
--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -562,7 +562,7 @@ wheels = [
 
 [[package]]
 name = "rae-budget-api"
-version = "0.1.9"
+version = "0.1.12"
 source = { virtual = "." }
 dependencies = [
     { name = "alembic" },


### PR DESCRIPTION
## Summary

After the run of release-please bumps that landed during today's hardening + Dependabot session, \`backend/pyproject.toml\` reached \`0.1.12\` but \`backend/uv.lock\` still recorded the \`rae-budget-api\` self-version as \`0.1.9\`. Running \`uv lock\` (inside the api container) re-resolved and updated only that self-version line — no transitive dependency changes.

## Diff

\`\`\`diff
 [[package]]
 name = "rae-budget-api"
-version = "0.1.9"
+version = "0.1.12"
\`\`\`

## Test plan
- [x] \`uv lock\` ran clean inside docker compose api
- [ ] CI green on this PR (backend test job exercises \`uv sync\` against the lockfile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)