### PR TITLE
ci: enable CodeQL static analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,45 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    # Weekly full scan on Sunday 06:00 UTC catches drift on `main`
+    # when no PRs have landed for a while.
+    - cron: '0 6 * * 0'
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: python
+            build-mode: none
+          - language: javascript-typescript
+            build-mode: none
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@f52b05f4acaaa234e44466e66d29050e135ea9ef  # v4.36.0
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          queries: security-extended
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@f52b05f4acaaa234e44466e66d29050e135ea9ef  # v4.36.0
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary
- Add `.github/workflows/codeql.yml` running CodeQL static analysis on Python (backend) and JavaScript/TypeScript (frontend)
- Triggers: every PR, every push to `main`, plus a weekly schedule (Sunday 06:00 UTC) to catch drift when `main` is quiet
- Uses the `security-extended` query suite for broader coverage than the default pack, while skipping the noisier maintainability rules from `security-and-quality`
- `build-mode: none` for both languages (no compilation step needed for Python/JS-TS)
- Actions pinned to commit SHAs; workflow has `contents: read` at the top with `security-events: write` scoped to the analyze job

## Why this complements existing hardening
- `pip-audit` / `pnpm audit` catch known CVEs in **dependencies**
- CodeQL catches vulnerabilities in **our own code** (SQLi, XSS, path traversal, unsafe deserialization, etc.)
- Findings will surface in the repo's [Security tab](https://github.com/rae004/rae-budget/security/code-scanning)

## Test plan
- [ ] After merge, confirm the workflow runs on the first PR/push
- [ ] Check the Security → Code scanning tab for any initial findings
- [ ] Triage findings; if signal looks good and noise is low, consider gating PRs on the workflow later

🤖 Generated with [Claude Code](https://claude.com/claude-code)