### PR TITLE
fix: stop leaking exception messages in API error responses

### DIFF
--- a/backend/app/routes/bill_templates.py
+++ b/backend/app/routes/bill_templates.py
@@ -1,6 +1,6 @@
 import json
 
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, current_app, jsonify, request
 from pydantic import ValidationError
 
 from app.extensions import db
@@ -68,9 +68,10 @@ def create_bill_template():
 
         result = BillTemplateResponse.model_validate(template).model_dump(mode="json")
         return jsonify(result), 201
-    except Exception as e:
+    except Exception:
         session.rollback()
-        return jsonify({"error": str(e)}), 500
+        current_app.logger.exception("Unhandled exception in bill_templates route")
+        return jsonify({"error": "Internal server error"}), 500
     finally:
         session.close()
 
@@ -98,9 +99,10 @@ def update_bill_template(template_id: int):
 
         result = BillTemplateResponse.model_validate(template).model_dump(mode="json")
         return jsonify(result)
-    except Exception as e:
+    except Exception:
         session.rollback()
-        return jsonify({"error": str(e)}), 500
+        current_app.logger.exception("Unhandled exception in bill_templates route")
+        return jsonify({"error": "Internal server error"}), 500
     finally:
         session.close()
 
@@ -118,8 +120,9 @@ def delete_bill_template(template_id: int):
         session.commit()
 
         return "", 204
-    except Exception as e:
+    except Exception:
         session.rollback()
-        return jsonify({"error": str(e)}), 500
+        current_app.logger.exception("Unhandled exception in bill_templates route")
+        return jsonify({"error": "Internal server error"}), 500
     finally:
         session.close()

--- a/backend/app/routes/bills.py
+++ b/backend/app/routes/bills.py
@@ -1,6 +1,6 @@
 import json
 
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, current_app, jsonify, request
 from pydantic import ValidationError
 
 from app.extensions import db
@@ -77,9 +77,10 @@ def create_bill(pay_period_id: int):
 
         result = PayPeriodBillResponse.model_validate(bill).model_dump(mode="json")
         return jsonify(result), 201
-    except Exception as e:
+    except Exception:
         session.rollback()
-        return jsonify({"error": str(e)}), 500
+        current_app.logger.exception("Unhandled exception in bills route")
+        return jsonify({"error": "Internal server error"}), 500
     finally:
         session.close()
 
@@ -107,9 +108,10 @@ def update_bill(bill_id: int):
 
         result = PayPeriodBillResponse.model_validate(bill).model_dump(mode="json")
         return jsonify(result)
-    except Exception as e:
+    except Exception:
         session.rollback()
-        return jsonify({"error": str(e)}), 500
+        current_app.logger.exception("Unhandled exception in bills route")
+        return jsonify({"error": "Internal server error"}), 500
     finally:
         session.close()
 
@@ -127,8 +129,9 @@ def delete_bill(bill_id: int):
         session.commit()
 
         return "", 204
-    except Exception as e:
+    except Exception:
         session.rollback()
-        return jsonify({"error": str(e)}), 500
+        current_app.logger.exception("Unhandled exception in bills route")
+        return jsonify({"error": "Internal server error"}), 500
     finally:
         session.close()

--- a/backend/app/routes/categories.py
+++ b/backend/app/routes/categories.py
@@ -1,6 +1,6 @@
 import json
 
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, current_app, jsonify, request
 from pydantic import ValidationError
 
 from app.extensions import db
@@ -66,9 +66,10 @@ def create_category():
 
         result = CategoryResponse.model_validate(category).model_dump(mode="json")
         return jsonify(result), 201
-    except Exception as e:
+    except Exception:
         session.rollback()
-        return jsonify({"error": str(e)}), 500
+        current_app.logger.exception("Unhandled exception in categories route")
+        return jsonify({"error": "Internal server error"}), 500
     finally:
         session.close()
 
@@ -96,9 +97,10 @@ def update_category(category_id: int):
 
         result = CategoryResponse.model_validate(category).model_dump(mode="json")
         return jsonify(result)
-    except Exception as e:
+    except Exception:
         session.rollback()
-        return jsonify({"error": str(e)}), 500
+        current_app.logger.exception("Unhandled exception in categories route")
+        return jsonify({"error": "Internal server error"}), 500
     finally:
         session.close()
 
@@ -139,8 +141,9 @@ def delete_category(category_id: int):
         session.commit()
 
         return "", 204
-    except Exception as e:
+    except Exception:
         session.rollback()
-        return jsonify({"error": str(e)}), 500
+        current_app.logger.exception("Unhandled exception in categories route")
+        return jsonify({"error": "Internal server error"}), 500
     finally:
         session.close()

--- a/backend/app/routes/data_management.py
+++ b/backend/app/routes/data_management.py
@@ -3,7 +3,7 @@
 import json
 from datetime import UTC, datetime
 
-from flask import Blueprint, Response, jsonify, request
+from flask import Blueprint, Response, current_app, jsonify, request
 from pydantic import ValidationError
 
 from app.extensions import db
@@ -276,9 +276,10 @@ def import_data():
         )
 
         return jsonify(result.model_dump(mode="json")), 200
-    except Exception as e:
+    except Exception:
         session.rollback()
-        return jsonify({"error": str(e)}), 500
+        current_app.logger.exception("Unhandled exception in data_management route")
+        return jsonify({"error": "Internal server error"}), 500
     finally:
         session.close()
 
@@ -327,8 +328,9 @@ def reset_data():
         )
 
         return jsonify(result.model_dump(mode="json")), 200
-    except Exception as e:
+    except Exception:
         session.rollback()
-        return jsonify({"error": str(e)}), 500
+        current_app.logger.exception("Unhandled exception in data_management route")
+        return jsonify({"error": "Internal server error"}), 500
     finally:
         session.close()

--- a/backend/app/routes/pay_periods.py
+++ b/backend/app/routes/pay_periods.py
@@ -1,6 +1,6 @@
 import json
 
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, current_app, jsonify, request
 from pydantic import ValidationError
 
 from app.extensions import db
@@ -122,9 +122,10 @@ def create_pay_period():
 
         result = PayPeriodResponse.model_validate(pay_period).model_dump(mode="json")
         return jsonify(result), 201
-    except Exception as e:
+    except Exception:
         session.rollback()
-        return jsonify({"error": str(e)}), 500
+        current_app.logger.exception("Unhandled exception in pay_periods route")
+        return jsonify({"error": "Internal server error"}), 500
     finally:
         session.close()
 
@@ -152,9 +153,10 @@ def update_pay_period(pay_period_id: int):
 
         result = PayPeriodResponse.model_validate(pay_period).model_dump(mode="json")
         return jsonify(result)
-    except Exception as e:
+    except Exception:
         session.rollback()
-        return jsonify({"error": str(e)}), 500
+        current_app.logger.exception("Unhandled exception in pay_periods route")
+        return jsonify({"error": "Internal server error"}), 500
     finally:
         session.close()
 
@@ -172,9 +174,10 @@ def delete_pay_period(pay_period_id: int):
         session.commit()
 
         return "", 204
-    except Exception as e:
+    except Exception:
         session.rollback()
-        return jsonify({"error": str(e)}), 500
+        current_app.logger.exception("Unhandled exception in pay_periods route")
+        return jsonify({"error": "Internal server error"}), 500
     finally:
         session.close()
 
@@ -205,9 +208,10 @@ def repopulate_pay_period_bills(pay_period_id: int):
                 "bills_created": result["created"],
             }
         )
-    except Exception as e:
+    except Exception:
         session.rollback()
-        return jsonify({"error": str(e)}), 500
+        current_app.logger.exception("Unhandled exception in pay_periods route")
+        return jsonify({"error": "Internal server error"}), 500
     finally:
         session.close()
 
@@ -255,8 +259,9 @@ def repopulate_all_pay_period_bills():
                 "total_bills_created": total_created,
             }
         )
-    except Exception as e:
+    except Exception:
         session.rollback()
-        return jsonify({"error": str(e)}), 500
+        current_app.logger.exception("Unhandled exception in pay_periods route")
+        return jsonify({"error": "Internal server error"}), 500
     finally:
         session.close()

--- a/backend/app/routes/spending.py
+++ b/backend/app/routes/spending.py
@@ -1,7 +1,7 @@
 import json
 from datetime import UTC, datetime, timedelta
 
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, current_app, jsonify, request
 from pydantic import ValidationError
 from sqlalchemy import desc, func, select
 
@@ -158,9 +158,10 @@ def create_spending(pay_period_id: int):
 
         result = SpendingEntryResponse.model_validate(entry).model_dump(mode="json")
         return jsonify(result), 201
-    except Exception as e:
+    except Exception:
         session.rollback()
-        return jsonify({"error": str(e)}), 500
+        current_app.logger.exception("Unhandled exception in spending route")
+        return jsonify({"error": "Internal server error"}), 500
     finally:
         session.close()
 
@@ -188,9 +189,10 @@ def update_spending(spending_id: int):
 
         result = SpendingEntryResponse.model_validate(entry).model_dump(mode="json")
         return jsonify(result)
-    except Exception as e:
+    except Exception:
         session.rollback()
-        return jsonify({"error": str(e)}), 500
+        current_app.logger.exception("Unhandled exception in spending route")
+        return jsonify({"error": "Internal server error"}), 500
     finally:
         session.close()
 
@@ -208,8 +210,9 @@ def delete_spending(spending_id: int):
         session.commit()
 
         return "", 204
-    except Exception as e:
+    except Exception:
         session.rollback()
-        return jsonify({"error": str(e)}), 500
+        current_app.logger.exception("Unhandled exception in spending route")
+        return jsonify({"error": "Internal server error"}), 500
     finally:
         session.close()


### PR DESCRIPTION
## Summary
- 500-error handlers across all 6 route files were returning `str(e)` in the response body, exposing raw exception text (SQL fragments, table/column names, library internals) to API consumers
- CodeQL flagged this as `py/stack-trace-exposure` (19 sites, all `error` severity)
- Each handler now logs the exception server-side via `current_app.logger.exception(...)` and returns a generic `"Internal server error"` message to the client

## Files touched
- `backend/app/routes/bill_templates.py` (3 sites)
- `backend/app/routes/bills.py` (3 sites)
- `backend/app/routes/categories.py` (3 sites)
- `backend/app/routes/data_management.py` (2 sites)
- `backend/app/routes/pay_periods.py` (5 sites)
- `backend/app/routes/spending.py` (3 sites)

## Test plan
- [x] `ruff check` and `ruff format --check` pass
- [x] All 181 backend tests pass
- [ ] After merge, confirm the 19 CodeQL alerts close automatically on the next scan
- [ ] Tail logs to confirm exceptions are now landing in `current_app.logger`

🤖 Generated with [Claude Code](https://claude.com/claude-code)