### PR TITLE
build: containerize the frontend dev server

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ rae-budget/
 ├── .github/workflows/
 │   ├── ci.yml                        # Lint + test + build + Codecov upload
 │   └── release-please.yml            # Auto-release management
-├── docker-compose.yml                # `api` + `postgres` services
+├── docker-compose.yml                # `api` + `postgres` + `frontend` services
 ├── release-please-config.json        # Synced versions across both packages
 ├── .release-please-manifest.json     # Current released version (truth source)
 ├── CHANGELOG.md                      # Owned by release-please
@@ -79,19 +79,23 @@ rae-budget/
 # 1. Env file (one-time)
 cp .env.example .env
 
-# 2. Start everything
+# 2. Start everything (api + postgres + frontend)
 docker compose up -d
-
-# 3. Frontend dev server (separate terminal)
-corepack enable   # one-time; activates pnpm from packageManager field
-cd frontend
-pnpm install --frozen-lockfile
-pnpm dev
 
 # URLs
 # Frontend: http://localhost:5173
 # API:      http://localhost:5000/api
 # Health:   http://localhost:5000/api/health
+```
+
+If HMR feels slow under Docker on macOS, run Vite directly on the host instead:
+
+```bash
+docker compose stop frontend
+corepack enable   # one-time; activates pnpm from packageManager field
+cd frontend
+pnpm install --frozen-lockfile
+pnpm dev
 ```
 
 Default Postgres credentials in `.env.example`: user `rae_budget`, password `localdev123`, db `rae_budget`.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ Personal budget tracking application for managing pay periods, bills, and spendi
 ## Prerequisites
 
 - Docker and Docker Compose
-- Node.js 22+ and Corepack (for frontend development; activates pnpm automatically via the `packageManager` field in `frontend/package.json`)
+
+(For running the frontend dev server on the host instead of in Docker, also install Node.js 22+ and Corepack.)
 
 ## Quick Start
 
@@ -47,27 +48,28 @@ Personal budget tracking application for managing pay periods, bills, and spendi
    cp .env.example .env
    ```
 
-2. **Start services**
+2. **Start everything**
    ```bash
    docker compose up -d
    ```
 
-3. **Verify backend is running**
-   ```bash
-   curl http://localhost:5000/api/health
-   ```
-
-4. **Start frontend development server**
-   ```bash
-   corepack enable                       # one-time, picks up pnpm version from package.json
-   cd frontend
-   pnpm install --frozen-lockfile
-   pnpm dev
-   ```
-
-5. **Access the application**
+3. **Access the application**
    - Frontend: http://localhost:5173
    - API: http://localhost:5000/api
+   - Health: http://localhost:5000/api/health
+
+### Running the frontend on the host instead
+
+If HMR feels slow under Docker on macOS, run Vite directly on the host:
+
+```bash
+corepack enable          # one-time, picks up pnpm version from package.json
+cd frontend
+pnpm install --frozen-lockfile
+pnpm dev
+```
+
+Then either stop the `frontend` service (`docker compose stop frontend`) or accept that two dev servers will be running.
 
 ## API Endpoints
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,5 +37,23 @@ services:
         condition: service_healthy
     restart: unless-stopped
 
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+    container_name: rae-budget-frontend
+    environment:
+      - VITE_PROXY_TARGET=http://api:5000
+    volumes:
+      - ./frontend:/app
+      # Anonymous volume keeps the container's node_modules from being shadowed
+      # by the host's, so platform-specific native bindings always match.
+      - /app/node_modules
+    ports:
+      - "5173:5173"
+    depends_on:
+      - api
+    restart: unless-stopped
+
 volumes:
   postgres_data:

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+dist
+coverage
+.git
+.gitignore
+.DS_Store
+*.log
+.env
+.env.local

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:24-alpine
+
+WORKDIR /app
+
+# pnpm is pinned in package.json's "packageManager" field; corepack
+# activates that exact version.
+COPY package.json pnpm-lock.yaml .npmrc ./
+RUN corepack enable && corepack prepare --activate
+
+RUN pnpm install --frozen-lockfile
+
+COPY . .
+
+EXPOSE 5173
+
+# --host binds Vite to 0.0.0.0 so the dev server is reachable from the host.
+CMD ["pnpm", "run", "dev", "--host"]

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     port: 5173,
     proxy: {
       "/api": {
-        target: "http://localhost:5000",
+        target: process.env.VITE_PROXY_TARGET || "http://localhost:5000",
         changeOrigin: true,
       },
     },


### PR DESCRIPTION
## Summary
- Adds a `frontend` service to `docker-compose.yml` so `docker compose up` now starts the API, Postgres, and the Vite dev server together
- New `frontend/Dockerfile` (node:24-alpine, corepack-activated pnpm, `pnpm run dev --host`) plus a `.dockerignore`
- `vite.config.ts` proxy target reads `VITE_PROXY_TARGET` so the in-container dev server can reach `http://api:5000` while the host fallback stays `http://localhost:5000`
- README/CLAUDE.md updated to reflect the new one-command local dev flow

## Test plan
- [ ] `docker compose up -d` starts api, postgres, and frontend cleanly
- [ ] http://localhost:5173 loads the app and hits the API through the proxy
- [ ] HMR still works when editing a file under `frontend/src/`
- [ ] Host-side `pnpm dev` escape hatch (per CLAUDE.md) still works after `docker compose stop frontend`

🤖 Generated with [Claude Code](https://claude.com/claude-code)