### PR TITLE
fix: clamp long category names in spending table + fix Docker frontend restart loop

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,9 @@ services:
     container_name: rae-budget-frontend
     environment:
       - VITE_PROXY_TARGET=http://api:5000
+      # pnpm 11 refuses to purge/rebuild node_modules without a TTY; CI=true
+      # lets the entrypoint's `pnpm install` run non-interactively.
+      - CI=true
     volumes:
       - ./frontend:/app
       # Anonymous volume keeps the container's node_modules from being shadowed

--- a/frontend/src/components/SpendingTable.tsx
+++ b/frontend/src/components/SpendingTable.tsx
@@ -40,6 +40,9 @@ export function SpendingTable({ entries, payPeriodId }: SpendingTableProps) {
     return category?.name ?? '-';
   };
 
+  const truncate = (text: string, max = 24): string =>
+    text.length > max ? `${text.slice(0, max - 1)}…` : text;
+
   const getCategoryColor = (categoryId: number | null): string => {
     if (!categoryId || !categories) return '#6b7280';
     const category = categories.find((c) => c.id === categoryId);
@@ -242,10 +245,11 @@ export function SpendingTable({ entries, payPeriodId }: SpendingTableProps) {
                 </td>
                 <td>
                   <span
-                    className="badge badge-sm"
+                    className="badge badge-sm whitespace-nowrap"
                     style={{ backgroundColor: getCategoryColor(entry.category_id), color: 'white' }}
+                    title={getCategoryName(entry.category_id)}
                   >
-                    {getCategoryName(entry.category_id)}
+                    {truncate(getCategoryName(entry.category_id))}
                   </span>
                 </td>
                 <td>{formatCurrency(entry.amount)}</td>


### PR DESCRIPTION
## Summary
Two unrelated local-dev/UI fixes.

### 1. Category pill clamp (`SpendingTable.tsx`)
Long or multi-word category names were breaking onto a new line while the colored badge did not, so the text spilled outside the pill. Names over 24 chars now truncate with an ellipsis and keep the full name in a `title` tooltip; `whitespace-nowrap` guarantees the pill stays a single line.

### 2. Docker frontend restart loop (`docker-compose.yml`)
pnpm 11 refuses to purge/rebuild `node_modules` without a TTY (`ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`), which put the frontend container in a restart loop after the pnpm action-setup bump. Setting `CI=true` lets the entrypoint's `pnpm install` run non-interactively.

## Test plan
- `pnpm test SpendingTable` → 9/9 passing
- Frontend container starts cleanly (no restart loop)

🤖 Generated with [Claude Code](https://claude.com/claude-code)