### PR TITLE
fix: highlight autocomplete suggestions during keyboard navigation

### DIFF
--- a/frontend/src/components/DescriptionAutocomplete.tsx
+++ b/frontend/src/components/DescriptionAutocomplete.tsx
@@ -113,7 +113,7 @@ export function DescriptionAutocomplete({
                 <button
                   type="button"
                   className={`flex justify-between items-center w-full ${
-                    isHighlighted ? 'active' : ''
+                    isHighlighted ? 'bg-base-content/10' : ''
                   }`}
                   onMouseDown={(e) => {
                     e.preventDefault();


### PR DESCRIPTION
## Summary
Arrow-key navigation in the description autocomplete updated the highlighted index but rendered no visible highlight, while mouse hover worked. The DaisyUI `active` class no longer styles a menu button in DaisyUI 5; replaced it with an explicit `bg-base-content/10` tint so keyboard and mouse highlighting look identical (lighter hover color).

## Test plan
- `pnpm test DescriptionAutocomplete` → 9/9 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)