### PR TITLE
fix: use standard semver bumps in release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,8 +3,8 @@
   "release-type": "simple",
   "include-component-in-tag": false,
   "include-v-in-tag": true,
-  "bump-minor-pre-major": true,
-  "bump-patch-for-minor-pre-major": true,
+  "bump-minor-pre-major": false,
+  "bump-patch-for-minor-pre-major": false,
   "packages": {
     ".": {
       "package-name": "rae-budget",


### PR DESCRIPTION
## Summary
Make release-please apply **standard semver** instead of the pre-1.0 special-casing:

| Commit | Before (pre-major rules) | After |
|---|---|---|
| `fix:` | patch | patch |
| `feat:` | **patch** ⚠️ | **minor** |
| `feat!:` / `BREAKING CHANGE:` | minor | **major** |

Disables `bump-minor-pre-major` and `bump-patch-for-minor-pre-major`. The old settings silently downgraded `feat:` to a patch bump while on 0.x, which is why a recent `feat:` commit only bumped the patch version — and contradicted the behavior documented in `CLAUDE.md`.

We still control when to go 1.0: just land a breaking change when ready, rather than relying on special pre-major rules that diverge from the documented/expected behavior.

## Notes
- Only affects the **next** release PR; already-released versions are unchanged.
- Manifest stays at `0.1.15`; the next `feat:` will now produce `0.2.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)