### PR TITLE
fix: copy pnpm-workspace.yaml into frontend Docker build

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -3,8 +3,10 @@ FROM node:24-alpine
 WORKDIR /app
 
 # pnpm is pinned in package.json's "packageManager" field; corepack
-# activates that exact version.
-COPY package.json pnpm-lock.yaml .npmrc ./
+# activates that exact version. pnpm-workspace.yaml carries the dependency
+# overrides recorded in the lockfile — without it, --frozen-lockfile fails
+# with ERR_PNPM_LOCKFILE_CONFIG_MISMATCH.
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc ./
 RUN corepack enable && corepack prepare --activate
 
 RUN pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary
`docker compose up --build` failed on the frontend with:

```
[ERR_PNPM_LOCKFILE_CONFIG_MISMATCH] Cannot proceed with the frozen installation.
The current "overrides" configuration doesn't match the value found in the lockfile
```

The frontend `Dockerfile` copies only `package.json`, `pnpm-lock.yaml`, and `.npmrc` before `pnpm install --frozen-lockfile`. The recent undici security override lives in `pnpm-workspace.yaml` (where pnpm 10+ reads overrides) and is recorded in the lockfile — but that file wasn't copied into the image, so the container had no overrides config to match the lockfile against.

Fix: copy `pnpm-workspace.yaml` in alongside the other manifests.

## Test plan
- `docker compose build frontend` → succeeds
- `docker compose up -d` → all three services running; frontend serves on :5173

🤖 Generated with [Claude Code](https://claude.com/claude-code)